### PR TITLE
feat: add toggle for the cache dump apis

### DIFF
--- a/cmd/agent/root.go
+++ b/cmd/agent/root.go
@@ -17,11 +17,12 @@ var (
 	logDebug bool
 	logTrace bool
 
-	name           string
-	dryRun         bool
-	kubeConfigPath string
-	kubeContext    string
-	ippoolRef      string
+	name               string
+	dryRun             bool
+	enableCacheDumpAPI bool
+	kubeConfigPath     string
+	kubeContext        string
+	ippoolRef          string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -70,6 +71,7 @@ func init() {
 	rootCmd.Flags().StringVar(&kubeConfigPath, "kubeconfig", os.Getenv("KUBECONFIG"), "Path to the kubeconfig file")
 	rootCmd.Flags().StringVar(&kubeContext, "kubecontext", os.Getenv("KUBECONTEXT"), "Context name")
 	rootCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Run vm-dhcp-agent without starting the DHCP server")
+	rootCmd.Flags().BoolVar(&enableCacheDumpAPI, "enable-cache-dump-api", false, "Enable cache dump APIs")
 	rootCmd.Flags().StringVar(&ippoolRef, "ippool-ref", os.Getenv("IPPOOL_REF"), "The IPPool object the agent should sync with")
 }
 

--- a/cmd/agent/run.go
+++ b/cmd/agent/run.go
@@ -16,6 +16,7 @@ func run(ctx context.Context, options *config.AgentOptions) error {
 	agent := agent.NewAgent(ctx, options)
 
 	httpServerOptions := config.HTTPServerOptions{
+		DebugMode:     enableCacheDumpAPI,
 		DHCPAllocator: agent.DHCPAllocator,
 	}
 	s := server.NewHTTPServer(&httpServerOptions)

--- a/cmd/controller/root.go
+++ b/cmd/controller/root.go
@@ -19,6 +19,7 @@ var (
 	name                    string
 	noLeaderElection        bool
 	noAgent                 bool
+	enableCacheDumpAPI      bool
 	agentNamespace          string
 	agentImage              string
 	agentServiceAccountName string
@@ -83,6 +84,7 @@ func init() {
 	rootCmd.Flags().StringVar(&name, "name", os.Getenv("VM_DHCP_CONTROLLER_NAME"), "The name of the vm-dhcp-controller instance")
 	rootCmd.Flags().BoolVar(&noLeaderElection, "no-leader-election", false, "Run vm-dhcp-controller with leader-election disabled")
 	rootCmd.Flags().BoolVar(&noAgent, "no-agent", false, "Run vm-dhcp-controller without spawning agents")
+	rootCmd.Flags().BoolVar(&enableCacheDumpAPI, "enable-cache-dump-api", false, "Enable cache dump APIs")
 	rootCmd.Flags().BoolVar(&noDHCP, "no-dhcp", false, "Disable DHCP server on the spawned agents")
 	rootCmd.Flags().StringVar(&agentNamespace, "namespace", os.Getenv("AGENT_NAMESPACE"), "The namespace for the spawned agents")
 	rootCmd.Flags().StringVar(&agentImage, "image", os.Getenv("AGENT_IMAGE"), "The container image for the spawned agents")

--- a/cmd/controller/run.go
+++ b/cmd/controller/run.go
@@ -56,6 +56,7 @@ func run(options *config.ControllerOptions) error {
 	}
 
 	httpServerOptions := config.HTTPServerOptions{
+		DebugMode:        enableCacheDumpAPI,
 		IPAllocator:      management.IPAllocator,
 		CacheAllocator:   management.CacheAllocator,
 		MetricsAllocator: management.MetricsAllocator,

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -81,6 +81,7 @@ type AgentOptions struct {
 }
 
 type HTTPServerOptions struct {
+	DebugMode        bool
 	CacheAllocator   *cache.CacheAllocator
 	IPAllocator      *ipam.IPAllocator
 	DHCPAllocator    *dhcp.DHCPAllocator

--- a/pkg/server/http.go
+++ b/pkg/server/http.go
@@ -42,15 +42,20 @@ func (s *HTTPServer) registerProbeHandlers() {
 func (s *HTTPServer) RegisterControllerHandlers() {
 	s.registerProbeHandlers()
 
-	s.router.Handle("/ipams/{networkName:.*}", listIPByNetworkHandler(s.IPAllocator))
-	s.router.Handle("/caches/{networkName:.*}", listCacheByNetworkHandler(s.CacheAllocator))
+	if s.DebugMode {
+		s.router.Handle("/ipams/{networkName:.*}", listIPByNetworkHandler(s.IPAllocator))
+		s.router.Handle("/caches/{networkName:.*}", listCacheByNetworkHandler(s.CacheAllocator))
+	}
+
 	s.router.Handle("/metrics", metricsHandler(s.MetricsAllocator))
 }
 
 func (s *HTTPServer) RegisterAgentHandlers() {
 	s.registerProbeHandlers()
 
-	s.router.Handle("/leases", listLeaseHandler(s.DHCPAllocator))
+	if s.DebugMode {
+		s.router.Handle("/leases", listLeaseHandler(s.DHCPAllocator))
+	}
 }
 
 func (s *HTTPServer) Run() {


### PR DESCRIPTION
The cache dump APIs allow users to inspect the internal caches of the controller and agent. Usually, we don't need this; for security concerns, they should be disabled by default.

Introduced a command line option for both controller and agent commands: `--enable-cache-dump-api`. The cache dump APIs will be enabled only if the flag is set.