### PR TITLE
feat(agent): add flag to pass in nic name

### DIFF
--- a/cmd/agent/root.go
+++ b/cmd/agent/root.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/harvester/vm-dhcp-controller/pkg/config"
-	"github.com/harvester/vm-dhcp-controller/pkg/util"
 	"github.com/rancher/wrangler/pkg/kv"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/harvester/vm-dhcp-controller/pkg/agent"
+	"github.com/harvester/vm-dhcp-controller/pkg/config"
+	"github.com/harvester/vm-dhcp-controller/pkg/util"
 )
 
 var (
@@ -19,6 +21,7 @@ var (
 
 	name               string
 	dryRun             bool
+	nic                string
 	enableCacheDumpAPI bool
 	kubeConfigPath     string
 	kubeContext        string
@@ -45,6 +48,7 @@ var rootCmd = &cobra.Command{
 		ipPoolNamespace, ipPoolName := kv.RSplit(ippoolRef, "/")
 		options := &config.AgentOptions{
 			DryRun:         dryRun,
+			Nic:            nic,
 			KubeConfigPath: kubeConfigPath,
 			KubeContext:    kubeContext,
 			IPPoolRef: types.NamespacedName{
@@ -73,6 +77,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Run vm-dhcp-agent without starting the DHCP server")
 	rootCmd.Flags().BoolVar(&enableCacheDumpAPI, "enable-cache-dump-api", false, "Enable cache dump APIs")
 	rootCmd.Flags().StringVar(&ippoolRef, "ippool-ref", os.Getenv("IPPOOL_REF"), "The IPPool object the agent should sync with")
+	rootCmd.Flags().StringVar(&nic, "nic", agent.DefaultNetworkInterface, "The network interface the embedded DHCP server listens on")
 }
 
 // execute adds all child commands to the root command and sets flags appropriately.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -13,15 +12,13 @@ import (
 	"github.com/harvester/vm-dhcp-controller/pkg/dhcp"
 )
 
-const (
-	defaultInterval         = 10 * time.Second
-	defaultNetworkInterface = "eth1"
-)
+const DefaultNetworkInterface = "eth1"
 
 type Agent struct {
 	ctx context.Context
 
 	dryRun  bool
+	nic     string
 	poolRef types.NamespacedName
 
 	ippoolEventHandler *ippool.EventHandler
@@ -37,6 +34,7 @@ func NewAgent(ctx context.Context, options *config.AgentOptions) *Agent {
 		ctx: ctx,
 
 		dryRun:  options.DryRun,
+		nic:     options.Nic,
 		poolRef: options.IPPoolRef,
 
 		DHCPAllocator: dhcpAllocator,
@@ -63,7 +61,7 @@ func (a *Agent) Run() error {
 		case <-egctx.Done():
 			return nil
 		default:
-			return a.DHCPAllocator.Run(defaultNetworkInterface, a.dryRun)
+			return a.DHCPAllocator.Run(a.nic, a.dryRun)
 		}
 	})
 

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -75,6 +75,7 @@ type ControllerOptions struct {
 
 type AgentOptions struct {
 	DryRun         bool
+	Nic            string
 	KubeConfigPath string
 	KubeContext    string
 	IPPoolRef      types.NamespacedName


### PR DESCRIPTION
Added a new flag for the agent command to specify the name of the NIC that the embedded DHCP server should listen to. Usually, it's unnecessary because the default value `eth1` is the NIC the agents used. This might only be useful if someone wants to run the agent locally for testing.