### PR TITLE
feat(controller): support ippool disabled mode

### DIFF
--- a/pkg/apis/network.harvesterhci.io/v1alpha1/ippool.go
+++ b/pkg/apis/network.harvesterhci.io/v1alpha1/ippool.go
@@ -35,6 +35,9 @@ type IPPool struct {
 type IPPoolSpec struct {
 	IPv4Config  IPv4Config `json:"ipv4Config,omitempty"`
 	NetworkName string     `json:"networkName,omitempty"`
+
+	// +optional
+	Paused *bool `json:"paused,omitempty"`
 }
 
 type IPv4Config struct {


### PR DESCRIPTION
When an IPPool is disabled, its IPAM and MAC caches are cleaned up, the backing agent is down, which means no DHCP requests will be served on that specific VM network. The allocation records still remain in the status field so that when the IPPool is enabled again, it can be restored instantly.
