### PR TITLE
feat: recreate agent pods if agent image is updated

### DIFF
--- a/pkg/apis/network.harvesterhci.io/v1alpha1/ippool.go
+++ b/pkg/apis/network.harvesterhci.io/v1alpha1/ippool.go
@@ -4,6 +4,7 @@ import (
 	"github.com/rancher/wrangler/pkg/condition"
 	"github.com/rancher/wrangler/pkg/genericcondition"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 var (
@@ -92,6 +93,8 @@ type IPv4Status struct {
 }
 
 type PodReference struct {
-	Namespace string `json:"namespace,omitempty"`
-	Name      string `json:"name,omitempty"`
+	Namespace string    `json:"namespace,omitempty"`
+	Name      string    `json:"name,omitempty"`
+	Image     string    `json:"image,omitempty"`
+	UID       types.UID `json:"uid,omitempty"`
 }

--- a/pkg/controller/ippool/common.go
+++ b/pkg/controller/ippool/common.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/wrangler/pkg/kv"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/harvester/vm-dhcp-controller/pkg/apis/network.harvesterhci.io"
@@ -222,12 +223,14 @@ func (b *IPPoolBuilder) Exclude(ipAddressList ...string) *IPPoolBuilder {
 	return b
 }
 
-func (b *IPPoolBuilder) AgentPodRef(namespace, name string) *IPPoolBuilder {
+func (b *IPPoolBuilder) AgentPodRef(namespace, name, image, uid string) *IPPoolBuilder {
 	if b.ipPool.Status.AgentPodRef == nil {
 		b.ipPool.Status.AgentPodRef = new(networkv1.PodReference)
 	}
 	b.ipPool.Status.AgentPodRef.Namespace = namespace
 	b.ipPool.Status.AgentPodRef.Name = name
+	b.ipPool.Status.AgentPodRef.Image = image
+	b.ipPool.Status.AgentPodRef.UID = types.UID(uid)
 	return b
 }
 
@@ -292,12 +295,14 @@ func newIPPoolStatusBuilder() *ipPoolStatusBuilder {
 	}
 }
 
-func (b *ipPoolStatusBuilder) AgentPodRef(namespace, name string) *ipPoolStatusBuilder {
+func (b *ipPoolStatusBuilder) AgentPodRef(namespace, name, image, uid string) *ipPoolStatusBuilder {
 	if b.ipPoolStatus.AgentPodRef == nil {
 		b.ipPoolStatus.AgentPodRef = new(networkv1.PodReference)
 	}
 	b.ipPoolStatus.AgentPodRef.Namespace = namespace
 	b.ipPoolStatus.AgentPodRef.Name = name
+	b.ipPoolStatus.AgentPodRef.Image = image
+	b.ipPoolStatus.AgentPodRef.UID = types.UID(uid)
 	return b
 }
 
@@ -346,6 +351,15 @@ func newPodBuilder(namespace, name string) *podBuilder {
 			},
 		},
 	}
+}
+
+func (b *podBuilder) Container(name, repository, tag string) *podBuilder {
+	container := corev1.Container{
+		Name:  name,
+		Image: repository + ":" + tag,
+	}
+	b.pod.Spec.Containers = append(b.pod.Spec.Containers, container)
+	return b
 }
 
 func (b *podBuilder) PodReady(ready corev1.ConditionStatus) *podBuilder {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Currently, upgrading the vm-dhcp-controller does not upgrade the agents simultaneously, resulting in inconsistent versions between the controller and the agent.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

The IPPool object will contain additional fields holding the information of the agent Pod. The controller will also propagate the image name changes to all IPPool objects and recreate the agent Pods according to the up-to-date image name to ensure the running agents match the agent Pod reference in their corresponding IPPool objects.

**Related Issue:**

harvester/harvester#5058

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

```
$ kubectl -n harvester-system get deploy harvester-vm-dhcp-controller -o jsonpath='{.spec.template.spec.containers[0].image}'
rancher/harvester-vm-dhcp-controller:main-head

$ kubectl -n harvester-system get pods default-net-48-agent -o jsonpath='{.spec.containers[0].image}'  
rancher/harvester-vm-dhcp-agent:main-head
```

Upgrade the vm-dhcp-controller chart:

```
helm upgrade --install harvester-vm-dhcp-controller ./chart -f values.yaml --namespace=harvester-system --create-namespace
```

After the upgrade, check if the agent Pods are using the newer image:

```
$ kubectl -n harvester-system get deploy harvester-vm-dhcp-controller -o jsonpath='{.spec.template.spec.containers[0].image}'
starbops/harvester-vm-dhcp-controller:agent-upgrade-head

$ kubectl -n harvester-system get pods default-net-48-agent -o jsonpath='{.spec.containers[0].image}'                       
starbops/harvester-vm-dhcp-agent:agent-upgrade-head
```