### PR TITLE
fix: ensure safe names for generated agent pods

### DIFF
--- a/pkg/controller/ippool/common.go
+++ b/pkg/controller/ippool/common.go
@@ -15,6 +15,7 @@ import (
 	"github.com/harvester/vm-dhcp-controller/pkg/apis/network.harvesterhci.io"
 	networkv1 "github.com/harvester/vm-dhcp-controller/pkg/apis/network.harvesterhci.io/v1alpha1"
 	"github.com/harvester/vm-dhcp-controller/pkg/config"
+	"github.com/harvester/vm-dhcp-controller/pkg/util"
 )
 
 func prepareAgentPod(
@@ -25,7 +26,7 @@ func prepareAgentPod(
 	agentServiceAccountName string,
 	agentImage *config.Image,
 ) *corev1.Pod {
-	name := fmt.Sprintf("%s-%s-agent", ipPool.Namespace, ipPool.Name)
+	name := util.SafeAgentConcatName(ipPool.Namespace, ipPool.Name)
 
 	nadNamespace, nadName := kv.RSplit(ipPool.Spec.NetworkName, "/")
 	networks := []Network{

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -1,5 +1,35 @@
 package util
 
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
 const (
 	ExcludedMark = "EXCLUDED"
+
+	AgentSuffixName = "agent"
 )
+
+func agentConcatName(name ...string) string {
+	return strings.Join(append(name, AgentSuffixName), "-")
+}
+
+func SafeAgentConcatName(name ...string) string {
+	fullPath := strings.Join(name, "-")
+
+	if len(fullPath) < 58 {
+		return agentConcatName(fullPath)
+	}
+
+	digest := sha256.Sum256([]byte(fullPath))
+	// since we cut the string in the middle, the last char may not be compatible with what is expected in k8s
+	// we are checking and if necessary removing the last char
+	c := fullPath[50]
+	if 'a' <= c && c <= 'z' || '0' <= c && c <= '9' {
+		return agentConcatName(fullPath[0:51], hex.EncodeToString(digest[0:])[0:5])
+	}
+
+	return agentConcatName(fullPath[0:50], hex.EncodeToString(digest[0:])[0:6])
+}


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Related Issue:**

harvester/harvester#5072

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Create a very long name VM Network, eg.g `fi6cx9ca1kt1faq80k3ro9cowyumyjb67qdmg8fb9ydmz27rbk5btlg2m5avv3n`
2. Create the corresponding IPPool object with the same long name
3. The spawned agent Pod's name should be under 64 characters.