### PR TITLE
fix: terminate goroutines gracefully

### DIFF
--- a/cmd/agent/root.go
+++ b/cmd/agent/root.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/rancher/wrangler/pkg/kv"
-	"github.com/rancher/wrangler/pkg/signals"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/types"
@@ -44,7 +43,6 @@ var rootCmd = &cobra.Command{
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := signals.SetupSignalContext()
 		ipPoolNamespace, ipPoolName := kv.RSplit(ippoolRef, "/")
 		options := &config.AgentOptions{
 			DryRun:         dryRun,
@@ -57,7 +55,7 @@ var rootCmd = &cobra.Command{
 			},
 		}
 
-		if err := run(ctx, options); err != nil {
+		if err := run(options); err != nil {
 			fmt.Fprintf(os.Stderr, "%s\n", err.Error())
 			os.Exit(1)
 		}

--- a/cmd/agent/root.go
+++ b/cmd/agent/root.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 
 	"github.com/rancher/wrangler/pkg/kv"
+	"github.com/rancher/wrangler/pkg/signals"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/types"
@@ -44,7 +44,7 @@ var rootCmd = &cobra.Command{
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := context.Background()
+		ctx := signals.SetupSignalContext()
 		ipPoolNamespace, ipPoolName := kv.RSplit(ippoolRef, "/")
 		options := &config.AgentOptions{
 			DryRun:         dryRun,

--- a/cmd/agent/run.go
+++ b/cmd/agent/run.go
@@ -2,8 +2,13 @@ package main
 
 import (
 	"context"
+	"errors"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/harvester/vm-dhcp-controller/pkg/agent"
 	"github.com/harvester/vm-dhcp-controller/pkg/config"
@@ -13,7 +18,15 @@ import (
 func run(ctx context.Context, options *config.AgentOptions) error {
 	logrus.Infof("Starting VM DHCP Agent: %s", name)
 
-	agent := agent.NewAgent(ctx, options)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+
+	eg, egctx := errgroup.WithContext(ctx)
+
+	agent := agent.NewAgent(options)
 
 	httpServerOptions := config.HTTPServerOptions{
 		DebugMode:     enableCacheDumpAPI,
@@ -21,7 +34,42 @@ func run(ctx context.Context, options *config.AgentOptions) error {
 	}
 	s := server.NewHTTPServer(&httpServerOptions)
 	s.RegisterAgentHandlers()
-	go s.Run()
 
-	return agent.Run()
+	eg.Go(func() error {
+		return s.Run()
+	})
+
+	eg.Go(func() error {
+		return agent.Run(egctx)
+	})
+
+	eg.Go(func() error {
+		<-egctx.Done()
+		return s.Stop(egctx)
+	})
+
+	eg.Go(func() error {
+		for {
+			select {
+			case sig := <-sigCh:
+				logrus.Infof("received signal: %s", sig)
+				cancel()
+			case <-egctx.Done():
+				return egctx.Err()
+			}
+		}
+	})
+
+	if err := eg.Wait(); err != nil {
+		if errors.Is(err, context.Canceled) {
+			logrus.Info("context canceled")
+			return nil
+		} else {
+			return err
+		}
+	}
+
+	logrus.Info("finished clean")
+
+	return nil
 }

--- a/cmd/controller/run.go
+++ b/cmd/controller/run.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"log"
 
 	"github.com/rancher/wrangler/pkg/leader"
@@ -86,14 +85,5 @@ func run(options *config.ControllerOptions) error {
 		return nil
 	})
 
-	if err := eg.Wait(); err != nil {
-		if errors.Is(err, context.Canceled) {
-			logrus.Info("context canceled")
-			return nil
-		} else {
-			logrus.Fatalf("received error: %s", err)
-		}
-	}
-
-	return nil
+	return eg.Wait()
 }

--- a/cmd/webhook/run.go
+++ b/cmd/webhook/run.go
@@ -81,5 +81,7 @@ func run(ctx context.Context, cfg *rest.Config, options *config.Options) error {
 
 	<-ctx.Done()
 
+	logrus.Info("Stopping webhook server")
+
 	return nil
 }

--- a/pkg/dhcp/dhcp.go
+++ b/pkg/dhcp/dhcp.go
@@ -318,7 +318,7 @@ func (a *DHCPAllocator) DryRun(ctx context.Context, nic string) (err error) {
 	return nil
 }
 
-func (a *DHCPAllocator) Stop(nic string) (err error) {
+func (a *DHCPAllocator) stop(nic string) (err error) {
 	logrus.Infof("(dhcp.Stop) stopping DHCP service on nic %s", nic)
 
 	if a.servers[nic] == nil {
@@ -338,4 +338,17 @@ func (a *DHCPAllocator) ListAll(name string) (map[string]string, error) {
 	}
 
 	return leases, nil
+}
+
+func Cleanup(ctx context.Context, a *DHCPAllocator, nic string) <-chan error {
+	errCh := make(chan error)
+
+	go func() {
+		<-ctx.Done()
+		defer close(errCh)
+
+		errCh <- a.stop(nic)
+	}()
+
+	return errCh
 }

--- a/pkg/server/http.go
+++ b/pkg/server/http.go
@@ -75,8 +75,21 @@ func (s *HTTPServer) Run() error {
 	return s.srv.ListenAndServe()
 }
 
-func (s *HTTPServer) Stop(ctx context.Context) error {
+func (s *HTTPServer) stop(ctx context.Context) error {
 	logrus.Info("Stopping HTTP server")
 
 	return s.srv.Shutdown(ctx)
+}
+
+func Cleanup(ctx context.Context, srv *HTTPServer) <-chan error {
+	errCh := make(chan error)
+
+	go func() {
+		<-ctx.Done()
+		defer close(errCh)
+
+		errCh <- srv.stop(ctx)
+	}()
+
+	return errCh
 }

--- a/pkg/server/http.go
+++ b/pkg/server/http.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -16,6 +17,7 @@ const defaultPort = 8080
 
 type HTTPServer struct {
 	*config.HTTPServerOptions
+	srv    *http.Server
 	router *mux.Router
 }
 
@@ -58,10 +60,10 @@ func (s *HTTPServer) RegisterAgentHandlers() {
 	}
 }
 
-func (s *HTTPServer) Run() {
-	logrus.Infof("Starting HTTP server")
+func (s *HTTPServer) Run() error {
+	logrus.Info("Starting HTTP server")
 
-	srv := &http.Server{
+	s.srv = &http.Server{
 		Handler:      s.router,
 		Addr:         fmt.Sprintf(":%d", defaultPort),
 		WriteTimeout: 15 * time.Second,
@@ -70,5 +72,11 @@ func (s *HTTPServer) Run() {
 
 	logrus.Infof("Listening on port: %d", defaultPort)
 
-	logrus.Fatal(srv.ListenAndServe())
+	return s.srv.ListenAndServe()
+}
+
+func (s *HTTPServer) Stop(ctx context.Context) error {
+	logrus.Info("Stopping HTTP server")
+
+	return s.srv.Shutdown(ctx)
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The context is not propagated appropriately. Goroutines do not work together correctly if some of them encounter failure.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Passing down context and grouping goroutines to make them clean up resources after receiving the interrupt/terminate signal.

**Related Issue:**

harvester/harvester#5072

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Create an IPPool object (please adjust the content according to your environment setup).

```
cat <<EOF | kubectl apply -f -
apiVersion: network.harvesterhci.io/v1alpha1
kind: IPPool
metadata:
  name: net-48
  namespace: default
spec:
  ipv4Config:
    serverIP: 192.168.48.77
    cidr: 192.168.48.0/24
    pool:
      start: 192.168.48.81
      end: 192.168.48.90
    router: 192.168.48.1
  networkName: default/net-48
EOF
```

Wait a few seconds for the agent Pod to become ready. Monitor the log (keep it opened and start a new shell for the next step):

```
$ kubectl -n harvester-system logs default-net-48-agent -f
Defaulted container "agent" out of: agent, ip-setter (init)
time="2024-02-04T13:35:12Z" level=info msg="Starting VM DHCP Agent: default-net-48-agent"
time="2024-02-04T13:35:12Z" level=info msg="Starting HTTP server"
time="2024-02-04T13:35:12Z" level=info msg="Listening on port: 8080"
time="2024-02-04T13:35:12Z" level=info msg="monitor ippool default/net-48"
time="2024-02-04T13:35:12Z" level=info msg="(dhcp.Run) starting DHCP service on nic eth1"
time="2024-02-04T13:35:12Z" level=info msg="(eventhandler.EventListener) starting IPPool event listener"
time="2024-02-04T13:35:12Z" level=info msg="(controller.Run) starting IPPool controller"
time="2024-02-04T13:35:33Z" level=info msg="(controller.sync) UPDATE default/net-48"
```

Remove the IPPool object to trigger agent Pod teardown.

```
kubectl delete ippools.network.harvesterhci.io net-48
```

Go back to the log monitor. The teardown logs should look like the following:

```
$ kubectl -n harvester-system logs default-net-48-agent -f
...
time="2024-02-05T08:29:04Z" level=info msg="(controller.sync) UPDATE default/net-48"
time="2024-02-05T08:29:04Z" level=info msg="Stopping HTTP server"
time="2024-02-05T08:29:04Z" level=info msg="(eventhandler.Stop) stopping IPPool event listener"
time="2024-02-05T08:29:04Z" level=info msg="(controller.Stop) stopping IPPool controller"
time="2024-02-05T08:29:04Z" level=info msg="(eventhandler.Run) IPPool event listener terminated"
time="2024-02-05T08:29:04Z" level=info msg="(dhcp.Stop) stopping DHCP service on nic eth1"
http: Server closed
```