### PR TITLE
fix: update status with up-to-date agent image

### DIFF
--- a/pkg/controller/ippool/common.go
+++ b/pkg/controller/ippool/common.go
@@ -191,6 +191,14 @@ func NewIPPoolBuilder(namespace, name string) *IPPoolBuilder {
 	}
 }
 
+func (b *IPPoolBuilder) Annotation(key, value string) *IPPoolBuilder {
+	if b.ipPool.Annotations == nil {
+		b.ipPool.Annotations = make(map[string]string)
+	}
+	b.ipPool.Annotations[key] = value
+	return b
+}
+
 func (b *IPPoolBuilder) NetworkName(networkName string) *IPPoolBuilder {
 	b.ipPool.Spec.NetworkName = networkName
 	return b

--- a/pkg/controller/ippool/controller.go
+++ b/pkg/controller/ippool/controller.go
@@ -255,6 +255,8 @@ func (h *Handler) OnRemove(key string, ipPool *networkv1.IPPool) (*networkv1.IPP
 	return ipPool, nil
 }
 
+// DeployAgent reconciles ipPool and ensures there's an agent pod for it. The
+// returned status reports whether an agent pod is registered.
 func (h *Handler) DeployAgent(ipPool *networkv1.IPPool, status networkv1.IPPoolStatus) (networkv1.IPPoolStatus, error) {
 	logrus.Debugf("(ippool.DeployAgent) deploy agent for ippool %s/%s", ipPool.Namespace, ipPool.Name)
 
@@ -331,6 +333,11 @@ func (h *Handler) DeployAgent(ipPool *networkv1.IPPool, status networkv1.IPPoolS
 	return status, nil
 }
 
+// BuildCache reconciles ipPool and initializes the IPAM and MAC caches for it.
+// The source information comes from both ipPool's spec and status. Since
+// IPPool objects are deemed source of truths, BuildCache honors the state and
+// use it to load up internal caches. The returned status reports whether both
+// caches are fully initialized.
 func (h *Handler) BuildCache(ipPool *networkv1.IPPool, status networkv1.IPPoolStatus) (networkv1.IPPoolStatus, error) {
 	logrus.Debugf("(ippool.BuildCache) build ipam for ippool %s/%s", ipPool.Namespace, ipPool.Name)
 
@@ -386,6 +393,10 @@ func (h *Handler) BuildCache(ipPool *networkv1.IPPool, status networkv1.IPPoolSt
 	return status, nil
 }
 
+// MonitorAgent reconciles ipPool and keeps an eye on the agent pod. If the
+// running agent pod does not match to the one record in ipPool's status,
+// MonitorAgent tries to delete it. The returned status reports whether the
+// agent pod is ready.
 func (h *Handler) MonitorAgent(ipPool *networkv1.IPPool, status networkv1.IPPoolStatus) (networkv1.IPPoolStatus, error) {
 	logrus.Debugf("(ippool.MonitorAgent) monitor agent for ippool %s/%s", ipPool.Namespace, ipPool.Name)
 

--- a/pkg/controller/ippool/controller.go
+++ b/pkg/controller/ippool/controller.go
@@ -281,6 +281,8 @@ func (h *Handler) DeployAgent(ipPool *networkv1.IPPool, status networkv1.IPPoolS
 	}
 
 	if ipPool.Status.AgentPodRef != nil {
+		status.AgentPodRef.Image = h.agentImage.String()
+
 		pod, err := h.podCache.Get(ipPool.Status.AgentPodRef.Namespace, ipPool.Status.AgentPodRef.Name)
 		if err != nil {
 			if !apierrors.IsNotFound(err) {

--- a/pkg/controller/ippool/controller_test.go
+++ b/pkg/controller/ippool/controller_test.go
@@ -605,7 +605,7 @@ func TestHandler_DeployAgent(t *testing.T) {
 		}
 
 		_, err = handler.DeployAgent(givenIPPool, givenIPPool.Status)
-		assert.Equal(t, fmt.Sprintf("agent pod %s uid mismatch, waiting for removal then redeploy", testPodName), err.Error())
+		assert.Equal(t, fmt.Sprintf("agent pod %s uid mismatch", testPodName), err.Error())
 	})
 }
 
@@ -752,7 +752,7 @@ func TestHandler_MonitorAgent(t *testing.T) {
 		}
 
 		_, err = handler.MonitorAgent(givenIPPool, givenIPPool.Status)
-		assert.Equal(t, fmt.Sprintf("agent %s for ippool %s/%s is not ready", testPodName, testIPPoolNamespace, testIPPoolName), err.Error())
+		assert.Equal(t, fmt.Sprintf("agent pod %s not ready", testPodName), err.Error())
 	})
 
 	t.Run("agent pod ready", func(t *testing.T) {
@@ -821,10 +821,9 @@ func TestHandler_MonitorAgent(t *testing.T) {
 		}
 
 		_, err = handler.MonitorAgent(givenIPPool, givenIPPool.Status)
-		assert.Nil(t, err)
+		assert.Equal(t, fmt.Sprintf("agent pod %s obsolete and purged", testPodName), err.Error())
 
 		_, err = handler.podClient.Get(testPodNamespace, testPodName, metav1.GetOptions{})
-		assert.NotNil(t, err)
 		assert.Equal(t, fmt.Sprintf("pods \"%s\" not found", testPodName), err.Error())
 	})
 }

--- a/pkg/controller/ippool/controller_test.go
+++ b/pkg/controller/ippool/controller_test.go
@@ -506,6 +506,20 @@ func TestHandler_DeployAgent(t *testing.T) {
 			AgentPodRef(testPodNamespace, testPodName, testImage, "").Build()
 		givenNAD := newTestNetworkAttachmentDefinitionBuilder().
 			Label(clusterNetworkLabelKey, testClusterNetwork).Build()
+		givenPod, _ := prepareAgentPod(
+			NewIPPoolBuilder(testIPPoolNamespace, testIPPoolName).
+				ServerIP(testServerIP).
+				CIDR(testCIDR).
+				NetworkName(testNetworkName).Build(),
+			false,
+			testPodNamespace,
+			testClusterNetwork,
+			testServiceAccountName,
+			&config.Image{
+				Repository: testImageRepository,
+				Tag:        testImageTag,
+			},
+		)
 
 		expectedStatus := newTestIPPoolStatusBuilder().
 			AgentPodRef(testPodNamespace, testPodName, testImageNew, "").Build()
@@ -521,6 +535,8 @@ func TestHandler_DeployAgent(t *testing.T) {
 		assert.Nil(t, err, "mock resource should add into fake controller tracker")
 
 		k8sclientset := k8sfake.NewSimpleClientset()
+		err = k8sclientset.Tracker().Add(givenPod)
+		assert.Nil(t, err, "mock resource should add into fake controller tracker")
 
 		handler := Handler{
 			agentNamespace: testPodNamespace,


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The controller does not upgrade agent Pods after the controller is upgraded to a newer version.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Make sure the `ippool-register` control loop always update the image handle of `AgentPodRef` for each IPPool object being reconciled so that the `ippool-agent-monitor` control loop could remove the obsolete agent Pods according to that information.

**Related Issue:**

harvester/harvester#5188

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

For developers who want to verifying the fix:

1. Checkout the branch and build the artifacts
   ```
   export REPO=<your-handle>
   export PUSH=true
   make
   ```
2. Prepare a Harvester cluster (single node would be fine) in v1.3.0-rc3
3. Install the `harvester-vm-dhcp-controller` experimental add-on with the default value content (should be an empty string) on the cluster
   ```
   kubectl apply -f https://raw.githubusercontent.com/harvester/experimental-addons/main/harvester-vm-dhcp-controller/harvester-vm-dhcp-controller.yaml
   ```
4. Enable the add-on
5. Make sure you have a valid cluster network, network config, and VM network defined already
6. Create an IPPool object for the VM network, for example:
   ```
   $ cat <<EOF | kubectl apply -f -
   apiVersion: network.harvesterhci.io/v1alpha1
   kind: IPPool
   metadata:
     name: test-net
     namespace: default
   spec:
     ipv4Config:
       serverIP: 192.168.0.2
       cidr: 192.168.0.0/24
       pool:
         start: 192.168.0.101
         end: 192.168.0.200
     networkName: default/test-net
   EOF
   ```
7. Wait for the IPPool object becomes ready (`AgentReady==True`)
8. Edit the `harvester-vm-dhcp-controller` Addon object to upgrade to the version you built in step 1, for example:
   ```
     ...
     valueContent: |
       image:
         repository: starbops/harvester-vm-dhcp-controller
         tag: fix-5188-head
       agent
         image:
           repository: starbops/harvester-vm-dhcp-agent
           tag: fix-5188-head
       webhook
         image:
           repository: starbops/harvester-vm-dhcp-webhook
           tag: fix-5188-head
   ```
9. Observe the agent Pod for the IPPool object is upgraded after the controller upgraded (by checking its image repository and tag)

For QAs, there's no need to custom-build the artifacts. Just verify if the fix works by using the `main-head` tag (since the PR will have been merged then). QAs can start from step 2.