### PR TITLE
fix: handle server-ip-within-range case correctly

### DIFF
--- a/pkg/controller/ippool/controller.go
+++ b/pkg/controller/ippool/controller.go
@@ -393,7 +393,7 @@ func (h *Handler) BuildCache(ipPool *networkv1.IPPool, status networkv1.IPPoolSt
 	// (Re)build caches from IPPool status
 	if ipPool.Status.IPv4 != nil {
 		for ip, mac := range ipPool.Status.IPv4.Allocated {
-			if mac == util.ExcludedMark {
+			if mac == util.ExcludedMark || mac == util.ReservedMark {
 				continue
 			}
 			if _, err := h.ipAllocator.AllocateIP(ipPool.Spec.NetworkName, ip); err != nil {

--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -118,13 +118,23 @@ func LoadPool(ipPool *networkv1.IPPool) (pi PoolInfo, err error) {
 	return
 }
 
-func LoadAllocated(allocated map[string]string) (ipAddrList []netip.Addr) {
-	for ip := range allocated {
+// LoadAllocated returns the un-allocatable IP addresses in three types of IP
+// address lists, allocatedList, excludedList, and reservedList.
+func LoadAllocated(allocated map[string]string) (allocatedList, excludedList, reservedList []netip.Addr) {
+	for ip, val := range allocated {
 		ipAddr, err := netip.ParseAddr(ip)
 		if err != nil {
 			continue
 		}
-		ipAddrList = append(ipAddrList, ipAddr)
+
+		switch val {
+		case ExcludedMark:
+			excludedList = append(excludedList, ipAddr)
+		case ReservedMark:
+			reservedList = append(reservedList, ipAddr)
+		default:
+			allocatedList = append(allocatedList, ipAddr)
+		}
 	}
 	return
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Given an IPPool object with the following YAML:

```yaml
apiVersion: network.harvesterhci.io/v1alpha1
kind: IPPool
metadata:
  namespace: default
  name: test-net
spec:
  ipv4Config:
    cidr: 192.168.30.0/24
  networkName: default/test-net
```

The mutator will fill the missing `.spec.ipv4Config.serverIP` field, and since there's no router specified, the serverIP will be `192.168.30.1` by default. However, that IP address is within the allocatable range (as the mutator-filled `.spec.ipv4Config.pool.start` and `.spec.ipv4Config.pool.end` fields will be `192.168.30.1` and `192.168.30.254`, respectively.) In the previous version, though the server IP address will be marked as `RESERVED` under the `.status.ipv4.allocated` field, it wasn't handled adequately by the webhook and controller:

- The validating admission webhook treats the `RESERVED` IP address the same way as allocated IP addresses. It will fail when validating any further updating requests because it thinks the server IP address is already occupied.
- The cache-building control loop does not skip the `RESERVED` IP addresses. They should be skipped just like how we did to the excluded IPs.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

If the server IP is within the allocatable pool range, it will be marked as "RESERVED" and honored by the webhook and controller's cache-builder reconciliation loop.

- Splitting the allocated, excluded, and reserved IP address lists
- The validating webhook only checks if the server IP address falls into the allocated and excluded IP address lists
- The cache-building control loop skips to allocate reserved IP addresses

**Related Issue:**

harvester/harvester#5225

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Install and enable the `harvester-vm-dhcp-controller` add-on
   ```yaml
   apiVersion: harvesterhci.io/v1beta1
   kind: Addon
   metadata:
     labels:
       addon.harvesterhci.io/experimental: "true"
     namespace: harvester-system
     name: harvester-vm-dhcp-controller
   spec:
     chart: harvester-vm-dhcp-controller
     enabled: true
     repo: https://charts.harvesterhci.io
     valuesContent: |
       image:
         repository: starbops/harvester-vm-dhcp-controller
         tag: fix-5225-head
       agent:
         image:
           repository: starbops/harvester-vm-dhcp-agent
           tag: fix-5225-head
       webhook:
         image:
           repository: starbops/harvester-vm-dhcp-webhook
           tag: fix-5225-head
     version: 0.3.0
   ```
2. Prepare a VM Network (NAD) named `test-net`
3. Create a minimal IPPool object associated to the VM Network
   ```yaml
   apiVersion: network.harvesterhci.io/v1alpha1
   kind: IPPool
   metadata:
     namespace: default
     name: test-net
   spec:
     ipv4Config:
       cidr: 192.168.30.0/24
     networkName: default/test-net
   ```
4. Check the auto assigned DHCP server IP address. It should be recorded in `.spec.ipv4Config.serverIP` and marked as `RESERVED` under `.status.ipv4.allocated`
5. Create a new VM and attach to the `test-net` VM Network
6. A new IP address should be allocated for the VM and recorded under `.status.ipv4.allocated` field
7. Delete the VM
8. Delete the IPPool object
9. Check if the agent Pod `harvester-system/default-test-net-agent` is gone