### PR TITLE
fix(webhook): more robust cidr check for ippool

### DIFF
--- a/cmd/webhook/root.go
+++ b/cmd/webhook/root.go
@@ -13,12 +13,15 @@ import (
 	"github.com/harvester/webhook/pkg/config"
 )
 
+const defaultServiceCIDR = "10.53.0.0/16"
+
 var (
 	logDebug bool
 	logTrace bool
 
-	name    string
-	options config.Options
+	name        string
+	serviceCIDR string
+	options     config.Options
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -58,11 +61,14 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&logTrace, "trace", trace, "set logging level to trace")
 
 	rootCmd.Flags().StringVar(&name, "name", os.Getenv("VM_DHCP_AGENT_NAME"), "The name of the vm-dhcp-webhook instance")
+	rootCmd.Flags().StringVar(&serviceCIDR, "service-cidr", defaultServiceCIDR, "")
+
 	rootCmd.Flags().StringVar(&options.ControllerUsername, "controller-user", "harvester-vm-dhcp-controller", "The harvester controller username")
 	rootCmd.Flags().StringVar(&options.GarbageCollectionUsername, "gc-user", "system:serviceaccount:kube-system:generic-garbage-collector", "The system username that performs garbage collection")
 	rootCmd.Flags().StringVar(&options.Namespace, "namespace", os.Getenv("NAMESPACE"), "The harvester namespace")
 	rootCmd.Flags().IntVar(&options.HTTPSListenPort, "https-port", 8443, "HTTPS listen port")
 	rootCmd.Flags().IntVar(&options.Threadiness, "threadiness", 5, "Specify controller threads")
+
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/webhook/root.go
+++ b/cmd/webhook/root.go
@@ -61,14 +61,13 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&logTrace, "trace", trace, "set logging level to trace")
 
 	rootCmd.Flags().StringVar(&name, "name", os.Getenv("VM_DHCP_AGENT_NAME"), "The name of the vm-dhcp-webhook instance")
-	rootCmd.Flags().StringVar(&serviceCIDR, "service-cidr", defaultServiceCIDR, "")
+	rootCmd.Flags().StringVar(&serviceCIDR, "service-cidr", defaultServiceCIDR, "The service CIDR that the cluster is currently using")
 
 	rootCmd.Flags().StringVar(&options.ControllerUsername, "controller-user", "harvester-vm-dhcp-controller", "The harvester controller username")
 	rootCmd.Flags().StringVar(&options.GarbageCollectionUsername, "gc-user", "system:serviceaccount:kube-system:generic-garbage-collector", "The system username that performs garbage collection")
 	rootCmd.Flags().StringVar(&options.Namespace, "namespace", os.Getenv("NAMESPACE"), "The harvester namespace")
 	rootCmd.Flags().IntVar(&options.HTTPSListenPort, "https-port", 8443, "HTTPS listen port")
 	rootCmd.Flags().IntVar(&options.Threadiness, "threadiness", 5, "Specify controller threads")
-
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/webhook/run.go
+++ b/cmd/webhook/run.go
@@ -76,7 +76,7 @@ func run(ctx context.Context, cfg *rest.Config, options *config.Options) error {
 	webhookServer := server.NewWebhookServer(ctx, cfg, name, options)
 
 	if err := webhookServer.RegisterValidators(
-		ippool.NewValidator(c.nadCache, c.nodeCache, c.vmnetcfgCache),
+		ippool.NewValidator(serviceCIDR, c.nadCache, c.nodeCache, c.vmnetcfgCache),
 		vmnetcfg.NewValidator(c.ippoolCache),
 	); err != nil {
 		return err

--- a/cmd/webhook/run.go
+++ b/cmd/webhook/run.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/client-go/rest"
 
 	ctlcore "github.com/harvester/vm-dhcp-controller/pkg/generated/controllers/core"
-	ctlcorev1 "github.com/harvester/vm-dhcp-controller/pkg/generated/controllers/core/v1"
 	ctlcni "github.com/harvester/vm-dhcp-controller/pkg/generated/controllers/k8s.cni.cncf.io"
 	ctlcniv1 "github.com/harvester/vm-dhcp-controller/pkg/generated/controllers/k8s.cni.cncf.io/v1"
 	ctlkubevirt "github.com/harvester/vm-dhcp-controller/pkg/generated/controllers/kubevirt.io"
@@ -26,9 +25,8 @@ type caches struct {
 	ippoolCache   ctlnetworkv1.IPPoolCache
 	vmnetcfgCache ctlnetworkv1.VirtualMachineNetworkConfigCache
 
-	nadCache  ctlcniv1.NetworkAttachmentDefinitionCache
-	nodeCache ctlcorev1.NodeCache
-	vmCache   ctlkubevirtv1.VirtualMachineCache
+	nadCache ctlcniv1.NetworkAttachmentDefinitionCache
+	vmCache  ctlkubevirtv1.VirtualMachineCache
 }
 
 func newCaches(ctx context.Context, cfg *rest.Config, threadiness int) (*caches, error) {
@@ -51,7 +49,6 @@ func newCaches(ctx context.Context, cfg *rest.Config, threadiness int) (*caches,
 		ippoolCache:   networkFactory.Network().V1alpha1().IPPool().Cache(),
 		vmnetcfgCache: networkFactory.Network().V1alpha1().VirtualMachineNetworkConfig().Cache(),
 		nadCache:      cniFactory.K8s().V1().NetworkAttachmentDefinition().Cache(),
-		nodeCache:     coreFactory.Core().V1().Node().Cache(),
 		vmCache:       kubevirtFactory.Kubevirt().V1().VirtualMachine().Cache(),
 	}
 
@@ -76,7 +73,7 @@ func run(ctx context.Context, cfg *rest.Config, options *config.Options) error {
 	webhookServer := server.NewWebhookServer(ctx, cfg, name, options)
 
 	if err := webhookServer.RegisterValidators(
-		ippool.NewValidator(serviceCIDR, c.nadCache, c.nodeCache, c.vmnetcfgCache),
+		ippool.NewValidator(serviceCIDR, c.nadCache, c.vmnetcfgCache),
 		vmnetcfg.NewValidator(c.ippoolCache),
 	); err != nil {
 		return err

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -10,9 +10,10 @@ const (
 	ExcludedMark = "EXCLUDED"
 	ReservedMark = "RESERVED"
 
-	AgentSuffixName       = "agent"
-	NodeArgsAnnotationKey = "rke2.io/node-args"
-	ServiceCIDRFlag       = "--service-cidr"
+	AgentSuffixName        = "agent"
+	NodeArgsAnnotationKey  = "rke2.io/node-args"
+	ServiceCIDRFlag        = "--service-cidr"
+	ManagementNodeLabelKey = "node-role.kubernetes.io/control-plane"
 )
 
 func agentConcatName(name ...string) string {

--- a/pkg/webhook/common.go
+++ b/pkg/webhook/common.go
@@ -1,7 +1,7 @@
 package webhook
 
 const (
-	CreateErr = "could not create %s %s/%s because %w"
-	UpdateErr = "could not update %s %s/%s because %w"
-	DeleteErr = "could not delete %s %s/%s because %w"
+	CreateErr = "cannot create %s %s/%s because %w"
+	UpdateErr = "cannot update %s %s/%s because %w"
+	DeleteErr = "cannot delete %s %s/%s because %w"
 )

--- a/pkg/webhook/ippool/mutator_test.go
+++ b/pkg/webhook/ippool/mutator_test.go
@@ -194,7 +194,7 @@ func TestMutator_Create(t *testing.T) {
 					Exclude("172.19.64.129", "172.19.64.131", "172.19.64.132", "172.19.64.133", "172.19.64.134").Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not create IPPool %s/%s because fail to assign ip for dhcp server", testIPPoolNamespace, testIPPoolName),
+				err: fmt.Errorf("cannot create IPPool %s/%s because fail to assign ip for dhcp server", testIPPoolNamespace, testIPPoolName),
 			},
 		},
 		{
@@ -204,7 +204,7 @@ func TestMutator_Create(t *testing.T) {
 					CIDR("172.19.64.128/32").Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not create IPPool %s/%s because fail to assign ip for dhcp server", testIPPoolNamespace, testIPPoolName),
+				err: fmt.Errorf("cannot create IPPool %s/%s because fail to assign ip for dhcp server", testIPPoolNamespace, testIPPoolName),
 			},
 		},
 		{
@@ -214,7 +214,7 @@ func TestMutator_Create(t *testing.T) {
 					CIDR("172.19.64.128/31").Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not create IPPool %s/%s because fail to assign ip for dhcp server", testIPPoolNamespace, testIPPoolName),
+				err: fmt.Errorf("cannot create IPPool %s/%s because fail to assign ip for dhcp server", testIPPoolNamespace, testIPPoolName),
 			},
 		},
 		{

--- a/pkg/webhook/ippool/validator_test.go
+++ b/pkg/webhook/ippool/validator_test.go
@@ -78,7 +78,7 @@ func TestValidator_Create(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not create IPPool %s/%s because server ip %s is not within subnet", testIPPoolNamespace, testIPPoolName, testServerIPOutOfRange),
+				err: fmt.Errorf("cannot create IPPool %s/%s because server ip %s is not within subnet", testIPPoolNamespace, testIPPoolName, testServerIPOutOfRange),
 			},
 		},
 		{
@@ -91,7 +91,7 @@ func TestValidator_Create(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not create IPPool %s/%s because server ip %s cannot be the same as network ip", testIPPoolNamespace, testIPPoolName, "192.168.0.128"),
+				err: fmt.Errorf("cannot create IPPool %s/%s because server ip %s is the same as network ip", testIPPoolNamespace, testIPPoolName, "192.168.0.128"),
 			},
 		},
 		{
@@ -104,7 +104,7 @@ func TestValidator_Create(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not create IPPool %s/%s because server ip %s cannot be the same as broadcast ip", testIPPoolNamespace, testIPPoolName, "192.168.0.127"),
+				err: fmt.Errorf("cannot create IPPool %s/%s because server ip %s is the same as broadcast ip", testIPPoolNamespace, testIPPoolName, "192.168.0.127"),
 			},
 		},
 		{
@@ -118,7 +118,7 @@ func TestValidator_Create(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not create IPPool %s/%s because server ip %s cannot be the same as router ip", testIPPoolNamespace, testIPPoolName, "192.168.0.254"),
+				err: fmt.Errorf("cannot create IPPool %s/%s because server ip %s is the same as router ip", testIPPoolNamespace, testIPPoolName, "192.168.0.254"),
 			},
 		},
 		{
@@ -131,7 +131,7 @@ func TestValidator_Create(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not create IPPool %s/%s because ParseAddr(\"%s\"): IPv4 field has value >255", testIPPoolNamespace, testIPPoolName, "192.168.0.1000"),
+				err: fmt.Errorf("cannot create IPPool %s/%s because ParseAddr(\"%s\"): IPv4 field has value >255", testIPPoolNamespace, testIPPoolName, "192.168.0.1000"),
 			},
 		},
 		{
@@ -144,7 +144,7 @@ func TestValidator_Create(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not create IPPool %s/%s because router ip %s is not within subnet", testIPPoolNamespace, testIPPoolName, "192.168.1.1"),
+				err: fmt.Errorf("cannot create IPPool %s/%s because router ip %s is not within subnet", testIPPoolNamespace, testIPPoolName, "192.168.1.1"),
 			},
 		},
 		{
@@ -157,7 +157,7 @@ func TestValidator_Create(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not create IPPool %s/%s because router ip %s is the same as network ip", testIPPoolNamespace, testIPPoolName, "192.168.0.0"),
+				err: fmt.Errorf("cannot create IPPool %s/%s because router ip %s is the same as network ip", testIPPoolNamespace, testIPPoolName, "192.168.0.0"),
 			},
 		},
 		{
@@ -170,7 +170,7 @@ func TestValidator_Create(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not create IPPool %s/%s because router ip %s is the same as broadcast ip", testIPPoolNamespace, testIPPoolName, "192.168.0.255"),
+				err: fmt.Errorf("cannot create IPPool %s/%s because router ip %s is the same as broadcast ip", testIPPoolNamespace, testIPPoolName, "192.168.0.255"),
 			},
 		},
 		{
@@ -183,7 +183,7 @@ func TestValidator_Create(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not create IPPool %s/%s because ParseAddr(\"%s\"): IPv4 field has value >255", testIPPoolNamespace, testIPPoolName, "192.168.0.1000"),
+				err: fmt.Errorf("cannot create IPPool %s/%s because ParseAddr(\"%s\"): IPv4 field has value >255", testIPPoolNamespace, testIPPoolName, "192.168.0.1000"),
 			},
 		},
 		{
@@ -196,7 +196,7 @@ func TestValidator_Create(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not create IPPool %s/%s because start ip %s is not within subnet", testIPPoolNamespace, testIPPoolName, "192.168.1.100"),
+				err: fmt.Errorf("cannot create IPPool %s/%s because start ip %s is not within subnet", testIPPoolNamespace, testIPPoolName, "192.168.1.100"),
 			},
 		},
 		{
@@ -209,7 +209,7 @@ func TestValidator_Create(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not create IPPool %s/%s because start ip %s is the same as network ip", testIPPoolNamespace, testIPPoolName, "192.168.0.0"),
+				err: fmt.Errorf("cannot create IPPool %s/%s because start ip %s is the same as network ip", testIPPoolNamespace, testIPPoolName, "192.168.0.0"),
 			},
 		},
 		{
@@ -222,7 +222,7 @@ func TestValidator_Create(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not create IPPool %s/%s because start ip %s is the same as broadcast ip", testIPPoolNamespace, testIPPoolName, "192.168.0.255"),
+				err: fmt.Errorf("cannot create IPPool %s/%s because start ip %s is the same as broadcast ip", testIPPoolNamespace, testIPPoolName, "192.168.0.255"),
 			},
 		},
 		{
@@ -235,7 +235,7 @@ func TestValidator_Create(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not create IPPool %s/%s because ParseAddr(\"%s\"): IPv4 field has value >255", testIPPoolNamespace, testIPPoolName, "192.168.0.1000"),
+				err: fmt.Errorf("cannot create IPPool %s/%s because ParseAddr(\"%s\"): IPv4 field has value >255", testIPPoolNamespace, testIPPoolName, "192.168.0.1000"),
 			},
 		},
 		{
@@ -248,7 +248,7 @@ func TestValidator_Create(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not create IPPool %s/%s because end ip %s is not within subnet", testIPPoolNamespace, testIPPoolName, "192.168.1.100"),
+				err: fmt.Errorf("cannot create IPPool %s/%s because end ip %s is not within subnet", testIPPoolNamespace, testIPPoolName, "192.168.1.100"),
 			},
 		},
 		{
@@ -261,7 +261,7 @@ func TestValidator_Create(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not create IPPool %s/%s because end ip %s is the same as network ip", testIPPoolNamespace, testIPPoolName, "192.168.0.0"),
+				err: fmt.Errorf("cannot create IPPool %s/%s because end ip %s is the same as network ip", testIPPoolNamespace, testIPPoolName, "192.168.0.0"),
 			},
 		},
 		{
@@ -274,7 +274,7 @@ func TestValidator_Create(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not create IPPool %s/%s because end ip %s is the same as broadcast ip", testIPPoolNamespace, testIPPoolName, "192.168.0.255"),
+				err: fmt.Errorf("cannot create IPPool %s/%s because end ip %s is the same as broadcast ip", testIPPoolNamespace, testIPPoolName, "192.168.0.255"),
 			},
 		},
 		{
@@ -286,7 +286,7 @@ func TestValidator_Create(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not create IPPool default/net-1 because network-attachment-definitions.k8s.cni.cncf.io \"%s\" not found", "nonexist"),
+				err: fmt.Errorf("cannot create IPPool default/net-1 because network-attachment-definitions.k8s.cni.cncf.io \"%s\" not found", "nonexist"),
 			},
 		},
 		{
@@ -309,7 +309,7 @@ func TestValidator_Create(t *testing.T) {
 				},
 			},
 			expected: output{
-				err: fmt.Errorf("could not create IPPool %s/%s because cidr %s overlaps cluster service cidr %s", testIPPoolNamespace, testIPPoolName, testCIDROverlap, testServiceCIDR),
+				err: fmt.Errorf("cannot create IPPool %s/%s because cidr %s overlaps cluster service cidr %s", testIPPoolNamespace, testIPPoolName, testCIDROverlap, testServiceCIDR),
 			},
 		},
 		{
@@ -329,7 +329,7 @@ func TestValidator_Create(t *testing.T) {
 				},
 			},
 			expected: output{
-				err: fmt.Errorf("could not create IPPool %s/%s because cidr %s overlaps cluster service cidr %s", testIPPoolNamespace, testIPPoolName, testCIDROverlap, testServiceCIDR),
+				err: fmt.Errorf("cannot create IPPool %s/%s because cidr %s overlaps cluster service cidr %s", testIPPoolNamespace, testIPPoolName, testCIDROverlap, testServiceCIDR),
 			},
 		},
 	}
@@ -352,9 +352,8 @@ func TestValidator_Create(t *testing.T) {
 		}
 
 		nadCache := fakeclient.NetworkAttachmentDefinitionCache(clientset.K8sCniCncfIoV1().NetworkAttachmentDefinitions)
-		nodeCache := fakeclient.NodeCache(k8sclientset.CoreV1().Nodes)
 		vmnetCache := fakeclient.VirtualMachineNetworkConfigCache(clientset.NetworkV1alpha1().VirtualMachineNetworkConfigs)
-		validator := NewValidator(testServiceCIDR, nadCache, nodeCache, vmnetCache)
+		validator := NewValidator(testServiceCIDR, nadCache, vmnetCache)
 
 		err = validator.Create(&admission.Request{}, tc.given.ipPool)
 
@@ -411,7 +410,7 @@ func TestValidator_Update(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not update IPPool %s/%s because server ip %s is not within subnet", testIPPoolNamespace, testIPPoolName, testServerIPOutOfRange),
+				err: fmt.Errorf("cannot update IPPool %s/%s because server ip %s is not within subnet", testIPPoolNamespace, testIPPoolName, testServerIPOutOfRange),
 			},
 		},
 		{
@@ -428,7 +427,7 @@ func TestValidator_Update(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not update IPPool %s/%s because server ip %s cannot be the same as network ip", testIPPoolNamespace, testIPPoolName, "192.168.0.0"),
+				err: fmt.Errorf("cannot update IPPool %s/%s because server ip %s is the same as network ip", testIPPoolNamespace, testIPPoolName, "192.168.0.0"),
 			},
 		},
 		{
@@ -445,7 +444,7 @@ func TestValidator_Update(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not update IPPool %s/%s because server ip %s cannot be the same as broadcast ip", testIPPoolNamespace, testIPPoolName, "192.168.0.255"),
+				err: fmt.Errorf("cannot update IPPool %s/%s because server ip %s is the same as broadcast ip", testIPPoolNamespace, testIPPoolName, "192.168.0.255"),
 			},
 		},
 		{
@@ -464,7 +463,7 @@ func TestValidator_Update(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not update IPPool %s/%s because server ip %s cannot be the same as router ip", testIPPoolNamespace, testIPPoolName, "192.168.0.254"),
+				err: fmt.Errorf("cannot update IPPool %s/%s because server ip %s is the same as router ip", testIPPoolNamespace, testIPPoolName, "192.168.0.254"),
 			},
 		},
 		{
@@ -484,7 +483,7 @@ func TestValidator_Update(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not update IPPool %s/%s because server ip %s is already occupied", testIPPoolNamespace, testIPPoolName, "192.168.0.100"),
+				err: fmt.Errorf("cannot update IPPool %s/%s because server ip %s is already occupied", testIPPoolNamespace, testIPPoolName, "192.168.0.100"),
 			},
 		},
 		{
@@ -497,7 +496,7 @@ func TestValidator_Update(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not update IPPool %s/%s because ParseAddr(\"%s\"): IPv4 field has value >255", testIPPoolNamespace, testIPPoolName, "192.168.0.1000"),
+				err: fmt.Errorf("cannot update IPPool %s/%s because ParseAddr(\"%s\"): IPv4 field has value >255", testIPPoolNamespace, testIPPoolName, "192.168.0.1000"),
 			},
 		},
 		{
@@ -510,7 +509,7 @@ func TestValidator_Update(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not update IPPool %s/%s because router ip %s is not within subnet", testIPPoolNamespace, testIPPoolName, "192.168.1.1"),
+				err: fmt.Errorf("cannot update IPPool %s/%s because router ip %s is not within subnet", testIPPoolNamespace, testIPPoolName, "192.168.1.1"),
 			},
 		},
 		{
@@ -523,7 +522,7 @@ func TestValidator_Update(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not update IPPool %s/%s because router ip %s is the same as network ip", testIPPoolNamespace, testIPPoolName, "192.168.0.0"),
+				err: fmt.Errorf("cannot update IPPool %s/%s because router ip %s is the same as network ip", testIPPoolNamespace, testIPPoolName, "192.168.0.0"),
 			},
 		},
 		{
@@ -536,7 +535,7 @@ func TestValidator_Update(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not update IPPool %s/%s because router ip %s is the same as broadcast ip", testIPPoolNamespace, testIPPoolName, "192.168.0.255"),
+				err: fmt.Errorf("cannot update IPPool %s/%s because router ip %s is the same as broadcast ip", testIPPoolNamespace, testIPPoolName, "192.168.0.255"),
 			},
 		},
 		{
@@ -549,7 +548,7 @@ func TestValidator_Update(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not update IPPool %s/%s because ParseAddr(\"%s\"): IPv4 field has value >255", testIPPoolNamespace, testIPPoolName, "192.168.0.1000"),
+				err: fmt.Errorf("cannot update IPPool %s/%s because ParseAddr(\"%s\"): IPv4 field has value >255", testIPPoolNamespace, testIPPoolName, "192.168.0.1000"),
 			},
 		},
 		{
@@ -562,7 +561,7 @@ func TestValidator_Update(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not update IPPool %s/%s because start ip %s is not within subnet", testIPPoolNamespace, testIPPoolName, "192.168.1.100"),
+				err: fmt.Errorf("cannot update IPPool %s/%s because start ip %s is not within subnet", testIPPoolNamespace, testIPPoolName, "192.168.1.100"),
 			},
 		},
 		{
@@ -575,7 +574,7 @@ func TestValidator_Update(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not update IPPool %s/%s because start ip %s is the same as network ip", testIPPoolNamespace, testIPPoolName, "192.168.0.0"),
+				err: fmt.Errorf("cannot update IPPool %s/%s because start ip %s is the same as network ip", testIPPoolNamespace, testIPPoolName, "192.168.0.0"),
 			},
 		},
 		{
@@ -588,7 +587,7 @@ func TestValidator_Update(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not update IPPool %s/%s because start ip %s is the same as broadcast ip", testIPPoolNamespace, testIPPoolName, "192.168.0.255"),
+				err: fmt.Errorf("cannot update IPPool %s/%s because start ip %s is the same as broadcast ip", testIPPoolNamespace, testIPPoolName, "192.168.0.255"),
 			},
 		},
 		{
@@ -601,7 +600,7 @@ func TestValidator_Update(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not update IPPool %s/%s because ParseAddr(\"%s\"): IPv4 field has value >255", testIPPoolNamespace, testIPPoolName, "192.168.0.1000"),
+				err: fmt.Errorf("cannot update IPPool %s/%s because ParseAddr(\"%s\"): IPv4 field has value >255", testIPPoolNamespace, testIPPoolName, "192.168.0.1000"),
 			},
 		},
 		{
@@ -614,7 +613,7 @@ func TestValidator_Update(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not update IPPool %s/%s because end ip %s is not within subnet", testIPPoolNamespace, testIPPoolName, "192.168.1.100"),
+				err: fmt.Errorf("cannot update IPPool %s/%s because end ip %s is not within subnet", testIPPoolNamespace, testIPPoolName, "192.168.1.100"),
 			},
 		},
 		{
@@ -627,7 +626,7 @@ func TestValidator_Update(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not update IPPool %s/%s because end ip %s is the same as network ip", testIPPoolNamespace, testIPPoolName, "192.168.0.0"),
+				err: fmt.Errorf("cannot update IPPool %s/%s because end ip %s is the same as network ip", testIPPoolNamespace, testIPPoolName, "192.168.0.0"),
 			},
 		},
 		{
@@ -640,7 +639,7 @@ func TestValidator_Update(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not update IPPool %s/%s because end ip %s is the same as broadcast ip", testIPPoolNamespace, testIPPoolName, "192.168.0.255"),
+				err: fmt.Errorf("cannot update IPPool %s/%s because end ip %s is the same as broadcast ip", testIPPoolNamespace, testIPPoolName, "192.168.0.255"),
 			},
 		},
 		{
@@ -652,7 +651,7 @@ func TestValidator_Update(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not update IPPool default/net-1 because network-attachment-definitions.k8s.cni.cncf.io \"%s\" not found", "nonexist"),
+				err: fmt.Errorf("cannot update IPPool default/net-1 because network-attachment-definitions.k8s.cni.cncf.io \"%s\" not found", "nonexist"),
 			},
 		},
 		{
@@ -675,7 +674,7 @@ func TestValidator_Update(t *testing.T) {
 				},
 			},
 			expected: output{
-				err: fmt.Errorf("could not update IPPool %s/%s because cidr %s overlaps cluster service cidr %s", testIPPoolNamespace, testIPPoolName, testCIDROverlap, testServiceCIDR),
+				err: fmt.Errorf("cannot update IPPool %s/%s because cidr %s overlaps cluster service cidr %s", testIPPoolNamespace, testIPPoolName, testCIDROverlap, testServiceCIDR),
 			},
 		},
 		{
@@ -695,7 +694,7 @@ func TestValidator_Update(t *testing.T) {
 				},
 			},
 			expected: output{
-				err: fmt.Errorf("could not update IPPool %s/%s because cidr %s overlaps cluster service cidr %s", testIPPoolNamespace, testIPPoolName, testCIDROverlap, testServiceCIDR),
+				err: fmt.Errorf("cannot update IPPool %s/%s because cidr %s overlaps cluster service cidr %s", testIPPoolNamespace, testIPPoolName, testCIDROverlap, testServiceCIDR),
 			},
 		},
 		{
@@ -709,7 +708,32 @@ func TestValidator_Update(t *testing.T) {
 				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
 			},
 			expected: output{
-				err: fmt.Errorf("could not update IPPool %s/%s because server ip %s is already occupied", testIPPoolNamespace, testIPPoolName, testExcludedIP),
+				err: fmt.Errorf("cannot update IPPool %s/%s because server ip %s is already occupied", testIPPoolNamespace, testIPPoolName, testExcludedIP),
+			},
+		},
+		{
+			name: "server ip within the pool range",
+			given: input{
+				newIPPool: newTestIPPoolBuilder().
+					CIDR(testCIDR).
+					ServerIP(testServerIPWithinRange).
+					NetworkName(testNetworkName).
+					Allocated(testServerIPWithinRange, util.ReservedMark).Build(),
+				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
+			},
+		},
+		{
+			name: "server ip collides with excluded ip",
+			given: input{
+				newIPPool: newTestIPPoolBuilder().
+					CIDR(testCIDR).
+					ServerIP(testExcludedIP).
+					NetworkName(testNetworkName).
+					Allocated(testExcludedIP, util.ExcludedMark).Build(),
+				nad: newTestNetworkAttachmentDefinitionBuilder().Build(),
+			},
+			expected: output{
+				err: fmt.Errorf("cannot update IPPool %s/%s because server ip %s is already occupied", testIPPoolNamespace, testIPPoolName, testExcludedIP),
 			},
 		},
 		{
@@ -743,9 +767,8 @@ func TestValidator_Update(t *testing.T) {
 		}
 
 		nadCache := fakeclient.NetworkAttachmentDefinitionCache(clientset.K8sCniCncfIoV1().NetworkAttachmentDefinitions)
-		nodeCache := fakeclient.NodeCache(k8sclientset.CoreV1().Nodes)
 		vmnetCache := fakeclient.VirtualMachineNetworkConfigCache(clientset.NetworkV1alpha1().VirtualMachineNetworkConfigs)
-		validator := NewValidator(testServiceCIDR, nadCache, nodeCache, vmnetCache)
+		validator := NewValidator(testServiceCIDR, nadCache, vmnetCache)
 
 		err = validator.Update(&admission.Request{}, tc.given.oldIPPool, tc.given.newIPPool)
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

We relied on a node annotation called `rke2.io/node-args` to extract the cluster-wide service CIDR string `--service-cidr`. It's an RKE2-specific annotation. Currently, there's no other good way to get such information via Kubernetes API calls. Plus, the implementation has a flaw iterating through all the nodes: worker nodes do not have such a flag so the validation procedure will fail if the cluster has any pure worker nodes.

On the other hand, we need a way for admin to specify the cluster-wide service CIDR if the cluster is not RKE2.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Load the cluster-wide service CIDR from the following sources:

- ~~`rke2.io/node-args` annotation in management Node objects~~
- Webhook command argument `--service-cidr`
- Default value `10.53.0.0/16`

Comparing the CIDR of the user-input IPPool object with the cluster-wide one. If overlap happens, reject the create/update requests.

**Related Issue:**

harvester/harvester#5153

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Install and enable the `harvester-vm-dhcp-controller` add-on
   ```yaml
   apiVersion: harvesterhci.io/v1beta1
   kind: Addon
   metadata:
     labels:
       addon.harvesterhci.io/experimental: "true"
     namespace: harvester-system
     name: harvester-vm-dhcp-controller
   spec:
     chart: harvester-vm-dhcp-controller
     enabled: true
     repo: https://charts.harvesterhci.io
     valuesContent: |
       image:
         repository: starbops/harvester-vm-dhcp-controller
         tag: fix-5153-head
       agent:
         image:
           repository: starbops/harvester-vm-dhcp-agent
           tag: fix-5153-head
       webhook:
         image:
           repository: starbops/harvester-vm-dhcp-webhook
           tag: fix-5153-head
     version: 0.3.0
   ```
2. Prepare a VM Network (NAD) named `test-net`
3. Create an IPPool object associated to the VM Network and overlapped with the cluster service CIDR using `kubectl`
   ```yaml
   apiVersion: network.harvesterhci.io/v1alpha1
   kind: IPPool
   metadata:
     namespace: default
     name: test-net
   spec:
     ipv4Config:
       serverIP: 10.53.0.2
       cidr: 10.53.0.0/16
       pool:
         start: 10.53.0.100
         end: 10.53.0.200
     networkName: default/test-net
   ```
4. The creation request should be rejected by the validating admission webhook:
   ```
   Error from server (InternalError): error when creating "STDIN": admission webhook "validator.harvester-system.harvester-vm-dhcp-controller-webhook" denied the request: Internal error occurred: could not create IPPool default/test-net because cidr 10.53.0.0/16 overlaps cluster service cidr 10.53.0.0/16
   ```