### PR TITLE
ci: remove dist directory

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - uses: actions/setup-go@v4
+    - uses: actions/setup-go@v5
       with:
         go-version: '1.21'
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /.dapper
 /.cache
 /bin
-/dist
 *.swp
 .idea
 *.DS_Store

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -17,7 +17,7 @@ RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0
 
 ENV DAPPER_ENV REPO PUSH TAG DRONE_TAG ARCH
 ENV DAPPER_SOURCE /go/src/github.com/harvester/vm-dhcp-controller
-ENV DAPPER_OUTPUT ./bin ./dist ./chart/crds
+ENV DAPPER_OUTPUT ./bin ./chart/crds
 ENV DAPPER_DOCKER_SOCKET true
 WORKDIR ${DAPPER_SOURCE}
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

In the [`Run dapper` step of the newly introduced GitHub Actions workflow](https://github.com/harvester/vm-dhcp-controller/actions/runs/8834051003/job/24254835831#step:5:490), there's an obscure error message that we didn't catch during PR #30 review:

```
time="2024-04-25T14:09:33Z" level=info msg="docker cp /go/src/github.com/harvester/vm-dhcp-controller/bin ."
time="2024-04-25T14:09:34Z" level=info msg="docker cp /go/src/github.com/harvester/vm-dhcp-controller/dist ."
Error response from daemon: Could not find the file /go/src/github.com/harvester/vm-dhcp-controller/dist in container vm-dhcp-controller-CapmMhO
time="2024-04-25T14:09:34Z" level=info msg="docker cp /go/src/github.com/harvester/vm-dhcp-controller/chart/crds chart"
```

We've removed the copy of binaries to the `dist/` directory but didn't remove it from `Dockerfile.dapper`. So Dapper will still try to copy the built artifacts from that directory, which no longer exist, thus causing the error.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Remove the `dist` directory from the list of `DAPPER_OUTPUT` environment variable in the `Dockerfile.dapper` file.

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Check the GitHub Actions output.