### PR TITLE
chore: bump go version to v1.22

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.21
+FROM registry.suse.com/bci/golang:1.22
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/vm-dhcp-controller
 
-go 1.21
+go 1.22
 
 replace (
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20191219222812-2987a591a72c


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Go v1.21 is going to be EOL soon.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Bump go version to v1.22

**Related Issue:**

harvester/harvester#6160

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
