### PR TITLE
fix: change ippool agent pod's initcontainer's imagepullpolicy to ifn…

### DIFF
--- a/pkg/controller/ippool/common.go
+++ b/pkg/controller/ippool/common.go
@@ -94,6 +94,7 @@ func prepareAgentPod(
 				{
 					Name:  "ip-setter",
 					Image: "busybox",
+					ImagePullPolicy: "IfNotPresent",
 					Command: []string{
 						"/bin/sh",
 						"-c",


### PR DESCRIPTION
…otpresent

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
vm-dhcp-controller dhcpserver-agent Pod Fails to Start in Air-Gapped Environment Due to ImagePullPolicy 'Always' Setting，The initialization container is stuck in the “pull image” state.

**Solution:**
change the imagepullpolicy of the  initialization container "ip-setter"  to "IfNotPresent"。

**Related Issue:**
[harvester/issues/6942](https://github.com/harvester/harvester/issues/6942)

**Test plan:**

