### PR TITLE
fix(agent): use agent image for initcontainer

### DIFF
--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -3,7 +3,7 @@
 FROM registry.suse.com/bci/bci-base:15.6
 
 RUN zypper -n rm container-suseconnect && \
-    zypper -n in curl dhcp-tools jq
+    zypper -n in curl dhcp-tools iproute2 jq
 
 ARG TARGETPLATFORM
 

--- a/pkg/controller/ippool/common.go
+++ b/pkg/controller/ippool/common.go
@@ -92,9 +92,9 @@ func prepareAgentPod(
 			ServiceAccountName: agentServiceAccountName,
 			InitContainers: []corev1.Container{
 				{
-					Name:  "ip-setter",
-					Image: "busybox",
-					ImagePullPolicy: "IfNotPresent",
+					Name:            "ip-setter",
+					Image:           agentImage.String(),
+					ImagePullPolicy: corev1.PullIfNotPresent,
 					Command: []string{
 						"/bin/sh",
 						"-c",


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The dhcp-agent pod's init container is using the `docker.io/library/busybox:latest` image. The image is not packed in the ISO image we shipped, so it'll cause trouble when users enable the harvester-vm-dhcp-controller add-on in air-gapped Harvester clusters.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Instead of using `docker.io/library/busybox:latest` to configure the dhcp-agent pod's IP address, use `docker.io/rancher/harvester-vm-dhcp-agent:<tag>` as the new image. Because of that, we need to add the `iproute2` package into the agent image.

**Related Issue:**

harvester/harvester#6942

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Install the harvester-vm-dhcp-controller experimental add-on
2. Enable the add-on
3. Create an IPPool object
4. Ensure the IPPool object's conditions are all good, especially the `AgentReady` one
5. Create a VM
6. Ensure the VM gets the IP address recorded in the corresponding VirtualMachineNetworkConfig object