### PR TITLE
chore: bump golang to v1.23.4

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.22
+FROM registry.suse.com/bci/golang:1.23
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -5,12 +5,12 @@ ENV ARCH $DAPPER_HOST_ARCH
 
 RUN zypper -n install tar gzip bash git docker less file curl wget
 
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.57.1
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.63.4
 
 # The docker version in dapper is too old to have buildx. Install it manually.
 RUN curl -sSfL https://github.com/docker/buildx/releases/download/v0.13.1/buildx-v0.13.1.linux-${ARCH} -o buildx-v0.13.1.linux-${ARCH} && \
-    chmod +x buildx-v0.13.1.linux-${ARCH} && \
-    mv buildx-v0.13.1.linux-${ARCH} /usr/local/bin/buildx
+	chmod +x buildx-v0.13.1.linux-${ARCH} && \
+	mv buildx-v0.13.1.linux-${ARCH} /usr/local/bin/buildx
 
 ## install controller-gen
 RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/vm-dhcp-controller
 
-go 1.22.8
+go 1.23.4
 
 replace (
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20191219222812-2987a591a72c


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Go 1.22 is soon to be EOL.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Bump the version to v1.23

**Related Issue:**

harvester/harvester#7336

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
