### PR TITLE
fix(controller): agent image name parsing

### DIFF
--- a/cmd/controller/root_test.go
+++ b/cmd/controller/root_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/harvester/vm-dhcp-controller/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseImageNameAndTag(t *testing.T) {
+	tests := []struct {
+		name     string
+		image    string
+		expected *config.Image
+		err      bool
+	}{
+		{
+			name:  "valid image with registry and tag",
+			image: "myregistry.local:5000/rancher/harvester-vm-dhcp-controller:v0.3.3",
+			expected: &config.Image{
+				Repository: "myregistry.local:5000/rancher/harvester-vm-dhcp-controller",
+				Tag:        "v0.3.3",
+			},
+			err: false,
+		},
+		{
+			name:  "valid image with only image and tag",
+			image: "rancher/harvester-vm-dhcp-controller:v0.3.3",
+			expected: &config.Image{
+				Repository: "rancher/harvester-vm-dhcp-controller",
+				Tag:        "v0.3.3",
+			},
+			err: false,
+		},
+		{
+			name:  "valid image without tag",
+			image: "rancher/harvester-vm-dhcp-controller",
+			expected: &config.Image{
+				Repository: "rancher/harvester-vm-dhcp-controller",
+				Tag:        "latest",
+			},
+			err: false,
+		},
+		{
+			name:  "valid image with port but no tag",
+			image: "myregistry.local:5000/rancher/harvester-vm-dhcp-controller",
+			expected: &config.Image{
+				Repository: "myregistry.local:5000/rancher/harvester-vm-dhcp-controller",
+				Tag:        "latest",
+			},
+			err: false,
+		},
+		{
+			name:     "invalid image with colon but no tag",
+			image:    "myregistry.local:5000/rancher/harvester-vm-dhcp-controller:",
+			expected: nil,
+			err:      true,
+		},
+		{
+			name:     "invalid image with multiple colons",
+			image:    "myregistry.local:5000/rancher/harvester-vm-dhcp-controller:v0.3.3:latest",
+			expected: nil,
+			err:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseImageNameAndTag(tt.image)
+			if tt.err {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Previously, enabling the Managed DHCP add-on with images containing port numbers in their name caused the controller pod to crash.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Handle the image name properly with support for the following cases:
- Names containing port numbers
- Names without tags (default to `latest`)

**Related Issue:**

harvester/harvester#7549

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Prepare a v1.4.1 Harvester cluster
2. Create the Managed DHCP Addon CR with the following content
   ```
   apiVersion: harvesterhci.io/v1beta1
   kind: Addon
   metadata:
     name: harvester-vm-dhcp-controller
     namespace: harvester-system
     labels:
       addon.harvesterhci.io/experimental: "true"
   spec:
     enabled: false
     repo: https://charts.harvesterhci.io
     version: 0.3.3
     chart: harvester-vm-dhcp-controller
     valuesContent: |
       image:
         repo: starbops/harvester-vm-dhcp-controller
         tag: fix-7549-head
       agent:
         image:
           repo: myregistry.local:5000/rancher/harvester-vm-dhcp-agent
   ```
3. Enable the add-on
4. The controller manager pod should be running fine without crashing