### PR TITLE
fix(controller): decouple ippool from nad

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To run the controller locally attaching to a remote cluster:
 # Make sure you have the correct config and context set
 export KUBECONFIG="$HOME/cluster.yaml"
 
-make run-controller ARGS="--name=test-controller --namespace=default --image=rancher/harvester-vm-dhcp-controller:main-head"
+make run-controller ARGS="--name=test-controller --namespace=default --image=rancher/harvester-vm-dhcp-agent:main-head"
 ```
 
 Same for the agent (for testing purposes):

--- a/pkg/controller/ippool/common.go
+++ b/pkg/controller/ippool/common.go
@@ -62,9 +62,9 @@ func prepareAgentPod(
 				multusNetworksAnnotationKey: string(networksStr),
 			},
 			Labels: map[string]string{
-				vmDHCPControllerLabelKey: "agent",
-				ipPoolNamespaceLabelKey:  ipPool.Namespace,
-				ipPoolNameLabelKey:       ipPool.Name,
+				vmDHCPControllerLabelKey:     "agent",
+				util.IPPoolNamespaceLabelKey: ipPool.Namespace,
+				util.IPPoolNameLabelKey:      ipPool.Name,
 			},
 			Name:      name,
 			Namespace: agentNamespace,

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -4,16 +4,20 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"strings"
+
+	"github.com/harvester/vm-dhcp-controller/pkg/apis/network.harvesterhci.io"
 )
 
 const (
 	ExcludedMark = "EXCLUDED"
 	ReservedMark = "RESERVED"
 
-	AgentSuffixName        = "agent"
-	NodeArgsAnnotationKey  = "rke2.io/node-args"
-	ServiceCIDRFlag        = "--service-cidr"
-	ManagementNodeLabelKey = "node-role.kubernetes.io/control-plane"
+	AgentSuffixName         = "agent"
+	NodeArgsAnnotationKey   = "rke2.io/node-args"
+	ServiceCIDRFlag         = "--service-cidr"
+	ManagementNodeLabelKey  = "node-role.kubernetes.io/control-plane"
+	IPPoolNamespaceLabelKey = network.GroupName + "/ippool-namespace"
+	IPPoolNameLabelKey      = network.GroupName + "/ippool-name"
 )
 
 func agentConcatName(name ...string) string {

--- a/pkg/util/fakeclient/networkattachmentdefinition.go
+++ b/pkg/util/fakeclient/networkattachmentdefinition.go
@@ -19,7 +19,7 @@ func (c NetworkAttachmentDefinitionClient) Update(nad *cniv1.NetworkAttachmentDe
 	return c(nad.Namespace).Update(context.TODO(), nad, metav1.UpdateOptions{})
 }
 func (c NetworkAttachmentDefinitionClient) Get(namespace, name string, options metav1.GetOptions) (*cniv1.NetworkAttachmentDefinition, error) {
-	panic("implement me")
+	return c(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 func (c NetworkAttachmentDefinitionClient) Create(nad *cniv1.NetworkAttachmentDefinition) (*cniv1.NetworkAttachmentDefinition, error) {
 	return c(nad.Namespace).Create(context.TODO(), nad, metav1.CreateOptions{})


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Previously, we implicitly required the IPPool name to be the same as the related NetworkAttachmentDefinition. There should be no such restriction since we already defined the `networkName` attributes in both IPPool and VirtualMachineNetworkConfig CRDs. The controllers should leverage the attributes to build the relationship between IPPools and NetworkAttachmentDefinitions and reference the target IPPool.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

IPPool, VirtualMachineNetworkConfig, and NetworkAttachmentDefinition resources have tight relations. Use labels to store the referenced IPPool name in NetworkAttachmentDefinition. VirtualMachineNetworkConifg will first use its NetworkName attribute to find the target NetworkAttachmentDefinition and determine where the target IPPool is.

**Related Issue:**

harvester/harvester#6240

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Prepare a Harvester cluster in v1.4.1
2. Install and enable the Managed DHCP add-on
```
cat <<EOF | kubectl apply -f -
apiVersion: harvesterhci.io/v1beta1
kind: Addon
metadata:
  name: harvester-vm-dhcp-controller
  namespace: harvester-system
  labels:
    addon.harvesterhci.io/experimental: "true"
spec:
  enabled: true
  repo: https://charts.harvesterhci.io
  version: 0.3.3
  chart: harvester-vm-dhcp-controller
  valuesContent: |
    image:
      repository: starbops/harvester-vm-dhcp-controller
      tag: fix-6240-head
    agent:
      image:
        repository: starbops/harvester-vm-dhcp-agent
        tag: fix-6240-head
    webhook:
      image:
        repository: starbops/harvester-vm-dhcp-webhook
        tag: fix-6240-head
EOF
```
3. Create a virtual machine network (NAD)
4. Create an IPPool related to the NAD (IMPORTANT: the name of the IPPool should be different from the NAD name in order to test the PR)
5. Create a virtual machine attached to the network
6. The virtual machine should get the IP address recorded in the VirtualMachineNetworkConfig and the IPPool
7. Removed the virtual machine
8. The VirtualMachineNetworkConfig should be removed automatically and the allocated IP address should be returned to the pool (check the IPPool's available IPs)