### PR TITLE
Increase robustness for the Managed DHCP add-on under disastrous events

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "v*" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "v*" ]
   schedule:
     - cron: '25 5 * * 6'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - main
+    - v*
 
 jobs:
   build-main:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - main
+    - v*
   pull_request:
 
 jobs:

--- a/cmd/agent/root.go
+++ b/cmd/agent/root.go
@@ -22,6 +22,7 @@ var (
 	dryRun             bool
 	nic                string
 	enableCacheDumpAPI bool
+	noLeaderElection   bool
 	kubeConfigPath     string
 	kubeContext        string
 	ippoolRef          string
@@ -74,6 +75,7 @@ func init() {
 	rootCmd.Flags().StringVar(&kubeContext, "kubecontext", os.Getenv("KUBECONTEXT"), "Context name")
 	rootCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Run vm-dhcp-agent without starting the DHCP server")
 	rootCmd.Flags().BoolVar(&enableCacheDumpAPI, "enable-cache-dump-api", false, "Enable cache dump APIs")
+	rootCmd.Flags().BoolVar(&noLeaderElection, "no-leader-election", false, "Run vm-dhcp-agent with leader election disabled")
 	rootCmd.Flags().StringVar(&ippoolRef, "ippool-ref", os.Getenv("IPPOOL_REF"), "The IPPool object the agent should sync with")
 	rootCmd.Flags().StringVar(&nic, "nic", agent.DefaultNetworkInterface, "The network interface the embedded DHCP server listens on")
 }

--- a/cmd/agent/run.go
+++ b/cmd/agent/run.go
@@ -1,12 +1,17 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
+	"github.com/rancher/wrangler/pkg/leader"
 	"github.com/rancher/wrangler/pkg/signals"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/harvester/vm-dhcp-controller/pkg/agent"
 	"github.com/harvester/vm-dhcp-controller/pkg/config"
@@ -18,37 +23,71 @@ func run(options *config.AgentOptions) error {
 
 	ctx := signals.SetupSignalContext()
 
-	agent := agent.NewAgent(options)
-
-	httpServerOptions := config.HTTPServerOptions{
-		DebugMode:     enableCacheDumpAPI,
-		DHCPAllocator: agent.DHCPAllocator,
-	}
-	s := server.NewHTTPServer(&httpServerOptions)
-	s.RegisterAgentHandlers()
-
-	eg, egctx := errgroup.WithContext(ctx)
-
-	eg.Go(func() error {
-		return s.Run()
-	})
-
-	eg.Go(func() error {
-		return agent.Run(egctx)
-	})
-
-	errCh := server.Cleanup(egctx, s)
-
-	if err := eg.Wait(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+	cfg, err := buildRestConfig(options.KubeConfigPath, options.KubeContext)
+	if err != nil {
 		return err
 	}
 
-	// Return cleanup error message if any
-	if err := <-errCh; err != nil {
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
 		return err
+	}
+
+	callback := func(ctx context.Context) {
+		agent := agent.NewAgent(options)
+
+		httpServerOptions := config.HTTPServerOptions{
+			DebugMode:     enableCacheDumpAPI,
+			DHCPAllocator: agent.DHCPAllocator,
+		}
+		s := server.NewHTTPServer(&httpServerOptions)
+		s.RegisterAgentHandlers()
+
+		eg, egctx := errgroup.WithContext(ctx)
+
+		eg.Go(func() error {
+			return s.Run()
+		})
+
+		eg.Go(func() error {
+			return agent.Run(egctx)
+		})
+
+		errCh := server.Cleanup(egctx, s)
+
+		if err := eg.Wait(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logrus.Errorf("agent runtime error: %v", err)
+		}
+
+		if err := <-errCh; err != nil {
+			logrus.Errorf("cleanup error: %v", err)
+		}
+	}
+
+	if noLeaderElection {
+		callback(ctx)
+		<-ctx.Done()
+	} else {
+		leader.RunOrDie(ctx, "kube-system", "vm-dhcp-agent-"+options.IPPoolRef.Name, client, callback)
 	}
 
 	logrus.Info("finished clean")
 
 	return nil
+}
+
+func buildRestConfig(kubeconfig, kubecontext string) (*rest.Config, error) {
+	if kubeconfig == "" {
+		if cfg, err := rest.InClusterConfig(); err == nil {
+			return cfg, nil
+		}
+	}
+
+	loadingRules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig}
+	overrides := &clientcmd.ConfigOverrides{}
+	if kubecontext != "" {
+		overrides.CurrentContext = kubecontext
+	}
+
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides).ClientConfig()
 }

--- a/cmd/controller/root_test.go
+++ b/cmd/controller/root_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/harvester/vm-dhcp-controller/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseImageNameAndTag(t *testing.T) {
+	tests := []struct {
+		name     string
+		image    string
+		expected *config.Image
+		err      bool
+	}{
+		{
+			name:  "valid image with registry and tag",
+			image: "myregistry.local:5000/rancher/harvester-vm-dhcp-controller:v0.3.3",
+			expected: &config.Image{
+				Repository: "myregistry.local:5000/rancher/harvester-vm-dhcp-controller",
+				Tag:        "v0.3.3",
+			},
+			err: false,
+		},
+		{
+			name:  "valid image with only image and tag",
+			image: "rancher/harvester-vm-dhcp-controller:v0.3.3",
+			expected: &config.Image{
+				Repository: "rancher/harvester-vm-dhcp-controller",
+				Tag:        "v0.3.3",
+			},
+			err: false,
+		},
+		{
+			name:  "valid image without tag",
+			image: "rancher/harvester-vm-dhcp-controller",
+			expected: &config.Image{
+				Repository: "rancher/harvester-vm-dhcp-controller",
+				Tag:        "latest",
+			},
+			err: false,
+		},
+		{
+			name:  "valid image with port but no tag",
+			image: "myregistry.local:5000/rancher/harvester-vm-dhcp-controller",
+			expected: &config.Image{
+				Repository: "myregistry.local:5000/rancher/harvester-vm-dhcp-controller",
+				Tag:        "latest",
+			},
+			err: false,
+		},
+		{
+			name:     "invalid image with colon but no tag",
+			image:    "myregistry.local:5000/rancher/harvester-vm-dhcp-controller:",
+			expected: nil,
+			err:      true,
+		},
+		{
+			name:     "invalid image with multiple colons",
+			image:    "myregistry.local:5000/rancher/harvester-vm-dhcp-controller:v0.3.3:latest",
+			expected: nil,
+			err:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseImageNameAndTag(tt.image)
+			if tt.err {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}

--- a/cmd/controller/run.go
+++ b/cmd/controller/run.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/rancher/wrangler/pkg/leader"
 	"github.com/rancher/wrangler/pkg/signals"
@@ -16,6 +17,7 @@ import (
 	"github.com/harvester/vm-dhcp-controller/pkg/config"
 	"github.com/harvester/vm-dhcp-controller/pkg/controller"
 	"github.com/harvester/vm-dhcp-controller/pkg/server"
+	"github.com/harvester/vm-dhcp-controller/pkg/util"
 )
 
 var (
@@ -45,6 +47,8 @@ func run(options *config.ControllerOptions) error {
 	if err != nil {
 		logrus.Fatalf("Error building controllers: %s", err.Error())
 	}
+
+	go util.CleanupTerminatingPods(ctx, client, options.AgentNamespace, "controller", time.Minute)
 
 	callback := func(ctx context.Context) {
 		if err := management.Register(ctx, cfg, controller.RegisterFuncList); err != nil {

--- a/cmd/webhook/run.go
+++ b/cmd/webhook/run.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"context"
+	"time"
 
+	"github.com/harvester/vm-dhcp-controller/pkg/util"
 	"github.com/harvester/webhook/pkg/config"
 	"github.com/harvester/webhook/pkg/server"
 	"github.com/rancher/wrangler/pkg/start"
 	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
 	ctlcore "github.com/harvester/vm-dhcp-controller/pkg/generated/controllers/core"
@@ -69,6 +72,13 @@ func run(ctx context.Context, cfg *rest.Config, options *config.Options) error {
 	if err != nil {
 		return err
 	}
+
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return err
+	}
+
+	go util.CleanupTerminatingPods(ctx, client, options.Namespace, "webhook", time.Minute)
 
 	webhookServer := server.NewWebhookServer(ctx, cfg, name, options)
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -41,6 +41,7 @@ func NewAgent(options *config.AgentOptions) *Agent {
 			options.IPPoolRef,
 			dhcpAllocator,
 			poolCache,
+			options.Nic,
 		),
 		poolCache: poolCache,
 	}

--- a/pkg/agent/ippool/controller.go
+++ b/pkg/agent/ippool/controller.go
@@ -23,6 +23,7 @@ type Controller struct {
 	poolRef       types.NamespacedName
 	dhcpAllocator *dhcp.DHCPAllocator
 	poolCache     map[string]string
+	nic           string
 }
 
 func NewController(
@@ -32,6 +33,7 @@ func NewController(
 	poolRef types.NamespacedName,
 	dhcpAllocator *dhcp.DHCPAllocator,
 	poolCache map[string]string,
+	nic string,
 ) *Controller {
 	return &Controller{
 		stopCh:        make(chan struct{}),
@@ -41,6 +43,7 @@ func NewController(
 		poolRef:       poolRef,
 		dhcpAllocator: dhcpAllocator,
 		poolCache:     poolCache,
+		nic:           nic,
 	}
 }
 

--- a/pkg/agent/ippool/event.go
+++ b/pkg/agent/ippool/event.go
@@ -33,6 +33,7 @@ type EventHandler struct {
 	poolRef       types.NamespacedName
 	dhcpAllocator *dhcp.DHCPAllocator
 	poolCache     map[string]string
+	nic           string
 }
 
 type Event struct {
@@ -49,6 +50,7 @@ func NewEventHandler(
 	poolRef types.NamespacedName,
 	dhcpAllocator *dhcp.DHCPAllocator,
 	poolCache map[string]string,
+	nic string,
 ) *EventHandler {
 	return &EventHandler{
 		kubeConfig:     kubeConfig,
@@ -57,6 +59,7 @@ func NewEventHandler(
 		poolRef:        poolRef,
 		dhcpAllocator:  dhcpAllocator,
 		poolCache:      poolCache,
+		nic:            nic,
 	}
 }
 
@@ -112,7 +115,7 @@ func (e *EventHandler) EventListener(ctx context.Context) {
 		},
 	}, cache.Indexers{})
 
-	controller := NewController(queue, indexer, informer, e.poolRef, e.dhcpAllocator, e.poolCache)
+	controller := NewController(queue, indexer, informer, e.poolRef, e.dhcpAllocator, e.poolCache, e.nic)
 
 	go controller.Run(1)
 

--- a/pkg/agent/ippool/ippool.go
+++ b/pkg/agent/ippool/ippool.go
@@ -10,6 +10,9 @@ import (
 func (c *Controller) Update(ipPool *networkv1.IPPool) error {
 	if !networkv1.CacheReady.IsTrue(ipPool) {
 		logrus.Warningf("ippool %s/%s is not ready", ipPool.Namespace, ipPool.Name)
+		if err := c.dhcpAllocator.Stop(c.nic); err != nil {
+			logrus.Errorf("(controller.Update) failed to stop DHCP service: %v", err)
+		}
 		return nil
 	}
 	if ipPool.Status.IPv4 == nil {

--- a/pkg/controller/ippool/common.go
+++ b/pkg/controller/ippool/common.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 
 	"github.com/harvester/vm-dhcp-controller/pkg/apis/network.harvesterhci.io"
 	networkv1 "github.com/harvester/vm-dhcp-controller/pkg/apis/network.harvesterhci.io/v1alpha1"
@@ -176,7 +177,7 @@ func prepareAgentDeployment(
 			Labels:    pod.Labels,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: &agentReplicas,
+			Replicas: pointer.Int32(agentReplicas),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: pod.Labels,
 			},

--- a/pkg/controller/ippool/common.go
+++ b/pkg/controller/ippool/common.go
@@ -8,16 +8,20 @@ import (
 
 	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/rancher/wrangler/pkg/kv"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 
 	"github.com/harvester/vm-dhcp-controller/pkg/apis/network.harvesterhci.io"
 	networkv1 "github.com/harvester/vm-dhcp-controller/pkg/apis/network.harvesterhci.io/v1alpha1"
 	"github.com/harvester/vm-dhcp-controller/pkg/config"
 	"github.com/harvester/vm-dhcp-controller/pkg/util"
 )
+
+const agentReplicas int32 = 2
 
 func prepareAgentPod(
 	ipPool *networkv1.IPPool,
@@ -148,6 +152,43 @@ func prepareAgentPod(
 						},
 					},
 				},
+			},
+		},
+	}, nil
+}
+
+func prepareAgentDeployment(
+	ipPool *networkv1.IPPool,
+	noDHCP bool,
+	agentNamespace string,
+	clusterNetwork string,
+	agentServiceAccountName string,
+	agentImage *config.Image,
+) (*appsv1.Deployment, error) {
+	pod, err := prepareAgentPod(ipPool, noDHCP, agentNamespace, clusterNetwork, agentServiceAccountName, agentImage)
+	if err != nil {
+		return nil, err
+	}
+
+	pod.ObjectMeta.Name = ""
+
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.SafeAgentConcatName(ipPool.Namespace, ipPool.Name),
+			Namespace: agentNamespace,
+			Labels:    pod.Labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: pointer.Int32(agentReplicas),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: pod.Labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      pod.Labels,
+					Annotations: pod.Annotations,
+				},
+				Spec: pod.Spec,
 			},
 		},
 	}, nil

--- a/pkg/controller/ippool/controller.go
+++ b/pkg/controller/ippool/controller.go
@@ -8,11 +8,13 @@ import (
 	"github.com/rancher/wrangler/pkg/kv"
 	"github.com/rancher/wrangler/pkg/relatedresource"
 	"github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/pointer"
 
 	"github.com/harvester/vm-dhcp-controller/pkg/apis/network.harvesterhci.io"
@@ -33,8 +35,9 @@ const (
 	multusNetworksAnnotationKey         = "k8s.v1.cni.cncf.io/networks"
 	holdIPPoolAgentUpgradeAnnotationKey = "network.harvesterhci.io/hold-ippool-agent-upgrade"
 
-	vmDHCPControllerLabelKey = network.GroupName + "/vm-dhcp-controller"
-	clusterNetworkLabelKey   = network.GroupName + "/clusternetwork"
+	vmDHCPControllerLabelKey       = network.GroupName + "/vm-dhcp-controller"
+	clusterNetworkLabelKey         = network.GroupName + "/clusternetwork"
+	agentReplicas            int32 = 2
 
 	setIPAddrScript = `
 #!/usr/bin/env sh
@@ -72,6 +75,7 @@ type Handler struct {
 	ippoolCache      ctlnetworkv1.IPPoolCache
 	podClient        ctlcorev1.PodClient
 	podCache         ctlcorev1.PodCache
+	deploymentClient kubernetes.Interface
 	nadClient        ctlcniv1.NetworkAttachmentDefinitionClient
 	nadCache         ctlcniv1.NetworkAttachmentDefinitionCache
 }
@@ -97,6 +101,7 @@ func Register(ctx context.Context, management *config.Management) error {
 		ippoolCache:      ippools.Cache(),
 		podClient:        pods,
 		podCache:         pods.Cache(),
+		deploymentClient: management.ClientSet,
 		nadClient:        nads,
 		nadCache:         nads.Cache(),
 	}
@@ -297,30 +302,23 @@ func (h *Handler) DeployAgent(ipPool *networkv1.IPPool, status networkv1.IPPoolS
 
 	if ipPool.Status.AgentPodRef != nil {
 		status.AgentPodRef.Image = h.getAgentImage(ipPool)
-		pod, err := h.podCache.Get(ipPool.Status.AgentPodRef.Namespace, ipPool.Status.AgentPodRef.Name)
+		dep, err := h.deploymentClient.AppsV1().Deployments(h.agentNamespace).Get(context.TODO(), ipPool.Status.AgentPodRef.Name, metav1.GetOptions{})
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
 				return status, err
 			}
 
-			logrus.Warningf("(ippool.DeployAgent) agent pod %s missing, redeploying", ipPool.Status.AgentPodRef.Name)
+			logrus.Warningf("(ippool.DeployAgent) agent deployment %s missing, redeploying", ipPool.Status.AgentPodRef.Name)
 		} else {
-			if pod.DeletionTimestamp != nil {
-				logrus.Warningf("(ippool.DeployAgent) deleting stuck agent pod %s", pod.Name)
-				if err := h.forceDeletePod(pod.Namespace, pod.Name); err != nil && !apierrors.IsNotFound(err) {
-					return status, err
-				}
-			} else {
-				if pod.GetUID() != ipPool.Status.AgentPodRef.UID {
-					return status, fmt.Errorf("agent pod %s uid mismatch", ipPool.Status.AgentPodRef.Name)
-				}
-
-				return status, nil
+			if dep.GetUID() != ipPool.Status.AgentPodRef.UID {
+				return status, fmt.Errorf("agent deployment %s uid mismatch", dep.Name)
 			}
+
+			return status, nil
 		}
 	}
 
-	agent, err := prepareAgentPod(ipPool, h.noDHCP, h.agentNamespace, clusterNetwork, h.agentServiceAccountName, h.agentImage)
+	agent, err := prepareAgentDeployment(ipPool, h.noDHCP, h.agentNamespace, clusterNetwork, h.agentServiceAccountName, h.agentImage)
 	if err != nil {
 		return status, err
 	}
@@ -331,7 +329,7 @@ func (h *Handler) DeployAgent(ipPool *networkv1.IPPool, status networkv1.IPPoolS
 
 	status.AgentPodRef.Image = h.agentImage.String()
 
-	agentPod, err := h.podClient.Create(agent)
+	agentDep, err := h.deploymentClient.AppsV1().Deployments(agent.Namespace).Create(context.TODO(), agent, metav1.CreateOptions{})
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			return status, nil
@@ -341,9 +339,9 @@ func (h *Handler) DeployAgent(ipPool *networkv1.IPPool, status networkv1.IPPoolS
 
 	logrus.Infof("(ippool.DeployAgent) agent for ippool %s/%s has been deployed", ipPool.Namespace, ipPool.Name)
 
-	status.AgentPodRef.Namespace = agentPod.Namespace
-	status.AgentPodRef.Name = agentPod.Name
-	status.AgentPodRef.UID = agentPod.GetUID()
+	status.AgentPodRef.Namespace = agentDep.Namespace
+	status.AgentPodRef.Name = agentDep.Name
+	status.AgentPodRef.UID = agentDep.GetUID()
 
 	return status, nil
 }
@@ -439,28 +437,35 @@ func (h *Handler) MonitorAgent(ipPool *networkv1.IPPool, status networkv1.IPPool
 		return status, fmt.Errorf("agent for ippool %s/%s is not deployed", ipPool.Namespace, ipPool.Name)
 	}
 
-	agentPod, err := h.podCache.Get(ipPool.Status.AgentPodRef.Namespace, ipPool.Status.AgentPodRef.Name)
+	sets := labels.Set{
+		vmDHCPControllerLabelKey:     "agent",
+		util.IPPoolNamespaceLabelKey: ipPool.Namespace,
+		util.IPPoolNameLabelKey:      ipPool.Name,
+	}
+
+	pods, err := h.podCache.List(h.agentNamespace, sets.AsSelector())
 	if err != nil {
 		return status, err
 	}
 
-	if agentPod.GetUID() != ipPool.Status.AgentPodRef.UID || agentPod.Spec.Containers[0].Image != ipPool.Status.AgentPodRef.Image {
-		if agentPod.DeletionTimestamp != nil {
-			return status, fmt.Errorf("agent pod %s marked for deletion", agentPod.Name)
+	for _, pod := range pods {
+		if pod.DeletionTimestamp != nil {
+			continue
 		}
 
-		if err := h.forceDeletePod(agentPod.Namespace, agentPod.Name); err != nil {
-			return status, err
+		if pod.Spec.Containers[0].Image != ipPool.Status.AgentPodRef.Image {
+			continue
 		}
 
-		return status, fmt.Errorf("agent pod %s obsolete and purged", agentPod.Name)
+		if isPodReady(pod) {
+			status.AgentPodRef.Namespace = pod.Namespace
+			status.AgentPodRef.Name = pod.Name
+			status.AgentPodRef.UID = pod.GetUID()
+			return status, nil
+		}
 	}
 
-	if !isPodReady(agentPod) {
-		return status, fmt.Errorf("agent pod %s not ready", agentPod.Name)
-	}
-
-	return status, nil
+	return status, fmt.Errorf("no ready agent pod for ippool %s/%s", ipPool.Namespace, ipPool.Name)
 }
 
 func isPodReady(pod *corev1.Pod) bool {

--- a/pkg/controller/ippool/controller.go
+++ b/pkg/controller/ippool/controller.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/pointer"
 
 	"github.com/harvester/vm-dhcp-controller/pkg/apis/network.harvesterhci.io"
@@ -33,8 +34,9 @@ const (
 	multusNetworksAnnotationKey         = "k8s.v1.cni.cncf.io/networks"
 	holdIPPoolAgentUpgradeAnnotationKey = "network.harvesterhci.io/hold-ippool-agent-upgrade"
 
-	vmDHCPControllerLabelKey = network.GroupName + "/vm-dhcp-controller"
-	clusterNetworkLabelKey   = network.GroupName + "/clusternetwork"
+	vmDHCPControllerLabelKey       = network.GroupName + "/vm-dhcp-controller"
+	clusterNetworkLabelKey         = network.GroupName + "/clusternetwork"
+	agentReplicas            int32 = 2
 
 	setIPAddrScript = `
 #!/usr/bin/env sh
@@ -72,6 +74,7 @@ type Handler struct {
 	ippoolCache      ctlnetworkv1.IPPoolCache
 	podClient        ctlcorev1.PodClient
 	podCache         ctlcorev1.PodCache
+	deploymentClient kubernetes.Interface
 	nadClient        ctlcniv1.NetworkAttachmentDefinitionClient
 	nadCache         ctlcniv1.NetworkAttachmentDefinitionCache
 }
@@ -97,6 +100,7 @@ func Register(ctx context.Context, management *config.Management) error {
 		ippoolCache:      ippools.Cache(),
 		podClient:        pods,
 		podCache:         pods.Cache(),
+		deploymentClient: management.ClientSet,
 		nadClient:        nads,
 		nadCache:         nads.Cache(),
 	}
@@ -297,30 +301,23 @@ func (h *Handler) DeployAgent(ipPool *networkv1.IPPool, status networkv1.IPPoolS
 
 	if ipPool.Status.AgentPodRef != nil {
 		status.AgentPodRef.Image = h.getAgentImage(ipPool)
-		pod, err := h.podCache.Get(ipPool.Status.AgentPodRef.Namespace, ipPool.Status.AgentPodRef.Name)
+		dep, err := h.deploymentClient.AppsV1().Deployments(h.agentNamespace).Get(context.TODO(), ipPool.Status.AgentPodRef.Name, metav1.GetOptions{})
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
 				return status, err
 			}
 
-			logrus.Warningf("(ippool.DeployAgent) agent pod %s missing, redeploying", ipPool.Status.AgentPodRef.Name)
+			logrus.Warningf("(ippool.DeployAgent) agent deployment %s missing, redeploying", ipPool.Status.AgentPodRef.Name)
 		} else {
-			if pod.DeletionTimestamp != nil {
-				logrus.Warningf("(ippool.DeployAgent) deleting stuck agent pod %s", pod.Name)
-				if err := h.forceDeletePod(pod.Namespace, pod.Name); err != nil && !apierrors.IsNotFound(err) {
-					return status, err
-				}
-			} else {
-				if pod.GetUID() != ipPool.Status.AgentPodRef.UID {
-					return status, fmt.Errorf("agent pod %s uid mismatch", ipPool.Status.AgentPodRef.Name)
-				}
-
-				return status, nil
+			if dep.GetUID() != ipPool.Status.AgentPodRef.UID {
+				return status, fmt.Errorf("agent deployment %s uid mismatch", dep.Name)
 			}
+
+			return status, nil
 		}
 	}
 
-	agent, err := prepareAgentPod(ipPool, h.noDHCP, h.agentNamespace, clusterNetwork, h.agentServiceAccountName, h.agentImage)
+	agent, err := prepareAgentDeployment(ipPool, h.noDHCP, h.agentNamespace, clusterNetwork, h.agentServiceAccountName, h.agentImage)
 	if err != nil {
 		return status, err
 	}
@@ -331,7 +328,7 @@ func (h *Handler) DeployAgent(ipPool *networkv1.IPPool, status networkv1.IPPoolS
 
 	status.AgentPodRef.Image = h.agentImage.String()
 
-	agentPod, err := h.podClient.Create(agent)
+	agentDep, err := h.deploymentClient.AppsV1().Deployments(agent.Namespace).Create(context.TODO(), agent, metav1.CreateOptions{})
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			return status, nil
@@ -341,9 +338,9 @@ func (h *Handler) DeployAgent(ipPool *networkv1.IPPool, status networkv1.IPPoolS
 
 	logrus.Infof("(ippool.DeployAgent) agent for ippool %s/%s has been deployed", ipPool.Namespace, ipPool.Name)
 
-	status.AgentPodRef.Namespace = agentPod.Namespace
-	status.AgentPodRef.Name = agentPod.Name
-	status.AgentPodRef.UID = agentPod.GetUID()
+	status.AgentPodRef.Namespace = agentDep.Namespace
+	status.AgentPodRef.Name = agentDep.Name
+	status.AgentPodRef.UID = agentDep.GetUID()
 
 	return status, nil
 }
@@ -439,28 +436,35 @@ func (h *Handler) MonitorAgent(ipPool *networkv1.IPPool, status networkv1.IPPool
 		return status, fmt.Errorf("agent for ippool %s/%s is not deployed", ipPool.Namespace, ipPool.Name)
 	}
 
-	agentPod, err := h.podCache.Get(ipPool.Status.AgentPodRef.Namespace, ipPool.Status.AgentPodRef.Name)
+	sets := labels.Set{
+		vmDHCPControllerLabelKey:     "agent",
+		util.IPPoolNamespaceLabelKey: ipPool.Namespace,
+		util.IPPoolNameLabelKey:      ipPool.Name,
+	}
+
+	pods, err := h.podCache.List(h.agentNamespace, sets.AsSelector())
 	if err != nil {
 		return status, err
 	}
 
-	if agentPod.GetUID() != ipPool.Status.AgentPodRef.UID || agentPod.Spec.Containers[0].Image != ipPool.Status.AgentPodRef.Image {
-		if agentPod.DeletionTimestamp != nil {
-			return status, fmt.Errorf("agent pod %s marked for deletion", agentPod.Name)
+	for _, pod := range pods {
+		if pod.DeletionTimestamp != nil {
+			continue
 		}
 
-		if err := h.forceDeletePod(agentPod.Namespace, agentPod.Name); err != nil {
-			return status, err
+		if pod.Spec.Containers[0].Image != ipPool.Status.AgentPodRef.Image {
+			continue
 		}
 
-		return status, fmt.Errorf("agent pod %s obsolete and purged", agentPod.Name)
+		if isPodReady(pod) {
+			status.AgentPodRef.Namespace = pod.Namespace
+			status.AgentPodRef.Name = pod.Name
+			status.AgentPodRef.UID = pod.GetUID()
+			return status, nil
+		}
 	}
 
-	if !isPodReady(agentPod) {
-		return status, fmt.Errorf("agent pod %s not ready", agentPod.Name)
-	}
-
-	return status, nil
+	return status, fmt.Errorf("no ready agent pod for ippool %s/%s", ipPool.Namespace, ipPool.Name)
 }
 
 func isPodReady(pod *corev1.Pod) bool {

--- a/pkg/controller/node/controller.go
+++ b/pkg/controller/node/controller.go
@@ -1,0 +1,86 @@
+package node
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/utils/pointer"
+
+	"github.com/harvester/vm-dhcp-controller/pkg/apis/network.harvesterhci.io"
+	"github.com/harvester/vm-dhcp-controller/pkg/config"
+	ctlcorev1 "github.com/harvester/vm-dhcp-controller/pkg/generated/controllers/core/v1"
+)
+
+const (
+	controllerName           = "vm-dhcp-node-controller"
+	vmDHCPControllerLabelKey = network.GroupName + "/vm-dhcp-controller"
+)
+
+type Handler struct {
+	agentNamespace string
+
+	podClient ctlcorev1.PodClient
+	podCache  ctlcorev1.PodCache
+}
+
+func Register(ctx context.Context, management *config.Management) error {
+	nodes := management.CoreFactory.Core().V1().Node()
+	pods := management.CoreFactory.Core().V1().Pod()
+
+	handler := &Handler{
+		agentNamespace: management.Options.AgentNamespace,
+		podClient:      pods,
+		podCache:       pods.Cache(),
+	}
+
+	nodes.OnChange(ctx, controllerName, handler.OnChange)
+
+	return nil
+}
+
+func (h *Handler) OnChange(key string, node *corev1.Node) (*corev1.Node, error) {
+	if node == nil {
+		return nil, nil
+	}
+
+	if isNodeReady(node) {
+		return node, nil
+	}
+
+	logrus.Debugf("(node.OnChange) node %s not ready, deleting agent pods", node.Name)
+
+	selector := labels.Set{vmDHCPControllerLabelKey: "agent"}.AsSelector()
+	pods, err := h.podCache.List(h.agentNamespace, selector)
+	if err != nil {
+		return node, err
+	}
+
+	for _, pod := range pods {
+		if pod.Spec.NodeName != node.Name {
+			continue
+		}
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+		logrus.Infof("(node.OnChange) deleting agent pod %s/%s on node %s", pod.Namespace, pod.Name, node.Name)
+		opts := metav1.DeleteOptions{GracePeriodSeconds: pointer.Int64(0)}
+		if err := h.podClient.Delete(pod.Namespace, pod.Name, &opts); err != nil && !apierrors.IsNotFound(err) {
+			return node, err
+		}
+	}
+
+	return node, nil
+}
+
+func isNodeReady(node *corev1.Node) bool {
+	for _, c := range node.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}

--- a/pkg/controller/setup.go
+++ b/pkg/controller/setup.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"github.com/harvester/vm-dhcp-controller/pkg/config"
 	"github.com/harvester/vm-dhcp-controller/pkg/controller/ippool"
+	"github.com/harvester/vm-dhcp-controller/pkg/controller/node"
 	"github.com/harvester/vm-dhcp-controller/pkg/controller/vm"
 	"github.com/harvester/vm-dhcp-controller/pkg/controller/vmnetcfg"
 )
@@ -13,6 +14,7 @@ type Config struct {
 
 var RegisterFuncList = []config.RegisterFunc{
 	ippool.Register,
+	node.Register,
 	vm.Register,
 	vmnetcfg.Register,
 }

--- a/pkg/dhcp/dhcp.go
+++ b/pkg/dhcp/dhcp.go
@@ -328,6 +328,12 @@ func (a *DHCPAllocator) stop(nic string) (err error) {
 	return a.servers[nic].Close()
 }
 
+// Stop stops the running DHCP server on the given network interface.
+// It is safe to call Stop multiple times for the same interface.
+func (a *DHCPAllocator) Stop(nic string) error {
+	return a.stop(nic)
+}
+
 func (a *DHCPAllocator) ListAll(name string) (map[string]string, error) {
 	a.mutex.RLock()
 	defer a.mutex.RUnlock()

--- a/pkg/util/pod.go
+++ b/pkg/util/pod.go
@@ -1,0 +1,54 @@
+package util
+
+import (
+	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+)
+
+// CleanupTerminatingPods forcibly deletes pods with the specified component label
+// that have been stuck in the Terminating state for longer than the given
+// threshold.
+func CleanupTerminatingPods(ctx context.Context, client kubernetes.Interface, namespace, component string, threshold time.Duration) {
+	if client == nil || namespace == "" || component == "" {
+		return
+	}
+
+	selector := labels.Set{"app.kubernetes.io/component": component}.AsSelector().String()
+	ticker := time.NewTicker(threshold / 2)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			pods, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
+			if err != nil {
+				logrus.Errorf("(CleanupTerminatingPods) list pods error: %v", err)
+				continue
+			}
+
+			for i := range pods.Items {
+				pod := &pods.Items[i]
+				if pod.DeletionTimestamp == nil {
+					continue
+				}
+				if time.Since(pod.DeletionTimestamp.Time) < threshold {
+					continue
+				}
+
+				logrus.Infof("(CleanupTerminatingPods) force deleting stuck pod %s/%s", pod.Namespace, pod.Name)
+				grace := int64(0)
+				if err := client.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{GracePeriodSeconds: &grace}); err != nil && !apierrors.IsNotFound(err) {
+					logrus.Errorf("(CleanupTerminatingPods) delete pod %s/%s error: %v", pod.Namespace, pod.Name, err)
+				}
+			}
+		}
+	}
+}

--- a/pkg/util/pod.go
+++ b/pkg/util/pod.go
@@ -8,6 +8,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -44,6 +45,14 @@ func CleanupTerminatingPods(ctx context.Context, client kubernetes.Interface, na
 				}
 
 				logrus.Infof("(CleanupTerminatingPods) force deleting stuck pod %s/%s", pod.Namespace, pod.Name)
+
+				if len(pod.Finalizers) > 0 {
+					patch := []byte(`{"metadata":{"finalizers":null}}`)
+					if _, err := client.CoreV1().Pods(pod.Namespace).Patch(ctx, pod.Name, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil && !apierrors.IsNotFound(err) {
+						logrus.Errorf("(CleanupTerminatingPods) patch pod %s/%s error: %v", pod.Namespace, pod.Name, err)
+					}
+				}
+
 				grace := int64(0)
 				if err := client.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{GracePeriodSeconds: &grace}); err != nil && !apierrors.IsNotFound(err) {
 					logrus.Errorf("(CleanupTerminatingPods) delete pod %s/%s error: %v", pod.Namespace, pod.Name, err)

--- a/vm-dhcp-controller.code-workspace
+++ b/vm-dhcp-controller.code-workspace
@@ -1,0 +1,14 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "go.useLanguageServer": true,
+    "go.goroot": "/usr/local/go",
+    "go.alternateTools": {
+      "go": "/usr/local/go/bin/go"
+    }
+  }
+}


### PR DESCRIPTION

**Problem**
 If a node encounters catastrophic events, such as the kubelet going down for no reason or the entire node crashing the controller does not forcefully remove agent pods stuck in termination state and no new agents are deployed, VMs that are reactivated on another node can no longer get their original IP addresses from the agent, if a downstream cluster consists of the affected VMs, this will be a catastrophe.

**Solution**

Below are the key changes with references to the affected files and line numbers.

A helper to instantly delete pods was added and used wherever stale pods are removed:

Helper definition in pkg/controller/ippool/controller.go lines 483‑485

Called when redeploying an agent pod if a previous instance is stuck in Terminating (lines 308‑312)

Used when purging outdated pods during monitoring (lines 444‑456)

Applied during cleanup of an IPPool (lines 488‑495)

Automatic cleanup routine now patches away pod finalizers before force‑deleting:

Function CleanupTerminatingPods implements this logic (lines 15‑58)

Executed on startup by controller and webhook binaries (controller run.go line 51, webhook run.go line 81)

DHCP servers can be stopped explicitly:

Public method Stop added at pkg/dhcp/dhcp.go lines 321‑334

The agent controller uses the new Stop to terminate DHCP when an IPPool isn’t ready:

Implementation in pkg/agent/ippool/ippool.go lines 10‑17

Network interface information is tracked by agent controllers to stop the correct DHCP instance:

New nic field in the event handler struct and constructor (lines 26‑37 and 46‑62)

Controller receives the interface at creation time (lines 118‑123)

A node controller was introduced to remove agent pods from nodes that turn unready:

Controller logic resides in pkg/controller/node/controller.go (lines 18‑86 show the constants, registration, and readiness check)

Registration of this controller happens in pkg/controller/setup.go (lines 15‑19)

These changes ensure stuck pods are force‑deleted, DHCP services can be stopped cleanly, and agents on failing nodes are removed automatically.





**Related Issue:**
https://github.com/harvester/harvester/issues/8205


