### PR TITLE
chore: bump go to v1.24.4

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,11 +1,11 @@
-FROM registry.suse.com/bci/golang:1.23
+FROM registry.suse.com/bci/golang:1.24
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH=$DAPPER_HOST_ARCH
 
 RUN zypper -n install tar gzip bash git docker less file curl wget
 
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.63.4
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s v2.1.6
 
 # The docker version in dapper is too old to have buildx. Install it manually.
 RUN curl -sSfL https://github.com/docker/buildx/releases/download/v0.13.1/buildx-v0.13.1.linux-${ARCH} -o buildx-v0.13.1.linux-${ARCH} && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/vm-dhcp-controller
 
-go 1.23.10
+go 1.24.4
 
 replace (
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20191219222812-2987a591a72c

--- a/pkg/agent/ippool/event.go
+++ b/pkg/agent/ippool/event.go
@@ -109,7 +109,7 @@ func (e *EventHandler) EventListener(ctx context.Context) {
 					queue.Add(Event{
 						key:             key,
 						action:          UPDATE,
-						poolName:        new.(*networkv1.IPPool).ObjectMeta.Name,
+						poolName:        new.(*networkv1.IPPool).Name,
 						poolNetworkName: new.(*networkv1.IPPool).Spec.NetworkName,
 					})
 				}

--- a/pkg/codegen/main.go
+++ b/pkg/codegen/main.go
@@ -20,7 +20,7 @@ func nadControllerInterfaceRefactor() {
 		logrus.Fatalf("failed to read the network-attachment-definition file: %v", err)
 	}
 
-	output := bytes.Replace(input, []byte("networkattachmentdefinitions"), []byte("network-attachment-definitions"), -1)
+	output := bytes.ReplaceAll(input, []byte("networkattachmentdefinitions"), []byte("network-attachment-definitions"))
 
 	if err = os.WriteFile(absPath, output, 0644); err != nil {
 		logrus.Fatalf("failed to update the network-attachment-definition file: %v", err)
@@ -28,7 +28,9 @@ func nadControllerInterfaceRefactor() {
 }
 
 func main() {
-	os.Unsetenv("GOPATH")
+	if err := os.Unsetenv("GOPATH"); err != nil {
+		logrus.Fatalf("failed to unset GOPATH: %v", err)
+	}
 	controllergen.Run(args.Options{
 		OutputPackage: "github.com/harvester/vm-dhcp-controller/pkg/generated",
 		Boilerplate:   "scripts/boilerplate.go.txt",

--- a/pkg/controller/vm/controller.go
+++ b/pkg/controller/vm/controller.go
@@ -69,7 +69,7 @@ func (h *Handler) OnChange(key string, vm *kubevirtv1.VirtualMachine) (*kubevirt
 
 	// Update network name for each network config if it's of type Multus
 	for _, network := range vm.Spec.Template.Spec.Networks {
-		if network.NetworkSource.Multus == nil {
+		if network.Multus == nil {
 			continue
 		}
 		nc, ok := ncm[network.Name]

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -21,7 +21,7 @@ func listIPByNetworkHandler(ipAllocator *ipam.IPAllocator) http.Handler {
 		set, err := ipAllocator.ListAll(networkName)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprintf(w, "failed to list ipam of %s: %s", networkName, err.Error())
+			_, _ = fmt.Fprintf(w, "failed to list ipam of %s: %s", networkName, err.Error())
 			return
 		}
 		payload, err := json.Marshal(set)
@@ -42,7 +42,7 @@ func listCacheByNetworkHandler(cacheAllocator *cache.CacheAllocator) http.Handle
 		set, err := cacheAllocator.ListAll(networkName)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprintf(w, "failed to list cache of %s: %s", networkName, err.Error())
+			_, _ = fmt.Fprintf(w, "failed to list cache of %s: %s", networkName, err.Error())
 			return
 		}
 		payload, err := json.Marshal(set)
@@ -61,7 +61,7 @@ func listLeaseHandler(dhcpAllocator *dhcp.DHCPAllocator) http.Handler {
 		set, err := dhcpAllocator.ListAll("")
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprintf(w, "cannot list leases: %s", err.Error())
+			_, _ = fmt.Fprintf(w, "cannot list leases: %s", err.Error())
 			return
 		}
 		payload, err := json.Marshal(set)


### PR DESCRIPTION
Also bumped golangci-lint to v2 and fixed all the issues flagged.

Signed-off-by: Zespre Chang <zespre.chang@suse.com>
