### PR TITLE
fix(controller): not creating vmnetcfgs for pod network vms

### DIFF
--- a/pkg/controller/vm/controller.go
+++ b/pkg/controller/vm/controller.go
@@ -87,6 +87,12 @@ func (h *Handler) OnChange(key string, vm *kubevirtv1.VirtualMachine) (*kubevirt
 		}
 	}
 
+	// If no network config is found, return early
+	if len(ncm) == 0 {
+		logrus.Infof("(vm.OnChange) no effective network configs found for vm %s, skipping", key)
+		return vm, nil
+	}
+
 	vmNetCfg := prepareVmNetCfg(vm, ncm)
 
 	oldVmNetCfg, err := h.vmnetcfgCache.Get(vm.Namespace, vm.Name)

--- a/pkg/controller/vmnetcfg/controller.go
+++ b/pkg/controller/vmnetcfg/controller.go
@@ -214,6 +214,11 @@ func (h *Handler) Allocate(vmNetCfg *networkv1.VirtualMachineNetworkConfig, stat
 		}
 	}
 
+	if len(ncStatuses) == 0 {
+		logrus.Infof("(vmnetcfg.Allocate) no network configs found for vmnetcfg %s/%s", vmNetCfg.Namespace, vmNetCfg.Name)
+		return status, fmt.Errorf("no network configs found for vmnetcfg %s/%s", vmNetCfg.Namespace, vmNetCfg.Name)
+	}
+
 	status.NetworkConfigs = ncStatuses
 
 	return status, nil


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The VirtualMachineNetworkConfig CRs for VMs attaching to the pod network, also known as the `management Network`, don't accurately reflect the truth. The Managed DHCP add-on does not serve DHCP requests for VMs on such a network.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Make the controller not create the corresponding VirtualMachineNetworkConfig CRs at all for such VMs. Even if they are created manually by the user, they won't be allocated with any IP addresses

**Related Issue:**

harvester/harvester#6624

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Case 1 - Create a VM on the `management Network`

1. Prepare a Harvester cluster in v1.5.0 (single-node formation is enough)
2. Apply and enable the Managed DHCP add-on by
   ```yaml
   apiVersion: harvesterhci.io/v1beta1
   kind: Addon
   metadata:
     labels:
       addon.harvesterhci.io/experimental: "true"
     name: harvester-vm-dhcp-controller
     namespace: harvester-system
   spec:
     chart: harvester-vm-dhcp-controller
     enabled: true
     repo: https://charts.harvesterhci.io
     valuesContent: |
       image:
         repository: starbops/harvester-vm-dhcp-controller
         tag: fix-6624-head
       agent:
         image:
           repository: starbops/harvester-vm-dhcp-agent
           tag: fix-6624-head
       webhook:
         image:
           repository: starbops/harvester-vm-dhcp-webhook
           tag: fix-6624-head
     version: 1.5.0
   ```
3. Create a VM attaching to the `management Network` network
4. There should be no VirtualMachineNetworkConfig CR created for the VM

Case 2 - Manually create a VirtualMachineNetworkConfig CR for the VM

1. Continue with the above case, create a VirtualMachineNetworkConfifg CR for the VM
   ```
   apiVersion: network.harvesterhci.io/v1alpha1
   kind: VirtualMachineNetworkConfig
   metadata:
     labels:
       harvesterhci.io/vmName: <vm-name>
     name: <vm-name>
     namespace: <vm-namespace>
   spec:
     vmName: <vm-name>
   ```
2. The `Allocated` condition of the VirtualMachineNetworkConfig CR should be `False` with a meaningful error message:
   ```
     - lastUpdateTime: "2025-06-23T11:42:36Z"
       message: no network configs found for vmnetcfg <vm-namespace>/<vm-name>
       reason: Error
       status: "False"
       type: Allocate
   ```