### PR TITLE
fix(webhook): check nad labels for associated nad

### DIFF
--- a/cmd/webhook/run.go
+++ b/cmd/webhook/run.go
@@ -74,7 +74,7 @@ func run(ctx context.Context, cfg *rest.Config, options *config.Options) error {
 
 	if err := webhookServer.RegisterValidators(
 		ippool.NewValidator(serviceCIDR, c.nadCache, c.vmnetcfgCache),
-		vmnetcfg.NewValidator(c.ippoolCache),
+		vmnetcfg.NewValidator(c.ippoolCache, c.nadCache),
 	); err != nil {
 		return err
 	}

--- a/pkg/webhook/vmnetcfg/validator.go
+++ b/pkg/webhook/vmnetcfg/validator.go
@@ -45,7 +45,13 @@ func (v *Validator) Create(request *admission.Request, newObj runtime.Object) er
 		}
 		ipPoolNamespace, ok := nad.Labels[util.IPPoolNamespaceLabelKey]
 		if !ok {
-			ipPoolNamespace = nadNamespace
+			return fmt.Errorf(
+				webhook.CreateErr,
+				vmNetCfg.Kind,
+				vmNetCfg.Namespace,
+				vmNetCfg.Name,
+				fmt.Errorf("%s label not found", util.IPPoolNamespaceLabelKey),
+			)
 		}
 		ipPoolName, ok := nad.Labels[util.IPPoolNameLabelKey]
 		if !ok {

--- a/pkg/webhook/vmnetcfg/validator_test.go
+++ b/pkg/webhook/vmnetcfg/validator_test.go
@@ -1,0 +1,150 @@
+package vmnetcfg
+
+import (
+	"testing"
+
+	"github.com/harvester/webhook/pkg/server/admission"
+	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	networkv1 "github.com/harvester/vm-dhcp-controller/pkg/apis/network.harvesterhci.io/v1alpha1"
+	"github.com/harvester/vm-dhcp-controller/pkg/controller/ippool"
+	"github.com/harvester/vm-dhcp-controller/pkg/controller/vmnetcfg"
+	"github.com/harvester/vm-dhcp-controller/pkg/generated/clientset/versioned/fake"
+	"github.com/harvester/vm-dhcp-controller/pkg/util"
+	"github.com/harvester/vm-dhcp-controller/pkg/util/fakeclient"
+)
+
+const (
+	testVmNetCfgNamespace = "default"
+	testVmNetCfgName      = "test-vmnetcfg"
+	testIPPoolNamespace   = "default"
+	testIPPoolName        = "test-pool"
+	testNADNamespace      = "default"
+	testNADName           = "test-net"
+	testNetworkName       = testNADNamespace + "/" + testNADName
+)
+
+func newTestVirtualMachineNetworkConfigBuilder() *vmnetcfg.VmNetCfgBuilder {
+	return vmnetcfg.NewVmNetCfgBuilder(testVmNetCfgNamespace, testVmNetCfgName)
+}
+
+func newTestIPPoolBuilder() *ippool.IPPoolBuilder {
+	return ippool.NewIPPoolBuilder(testIPPoolNamespace, testIPPoolName)
+}
+
+func newTestNetworkAttachmentDefinitionBuilder() *ippool.NetworkAttachmentDefinitionBuilder {
+	return ippool.NewNetworkAttachmentDefinitionBuilder(testNADNamespace, testNADName)
+}
+
+func TestValidator_Create(t *testing.T) {
+	type input struct {
+		vmNetCfg *networkv1.VirtualMachineNetworkConfig
+		ipPool   *networkv1.IPPool
+		nad      *cniv1.NetworkAttachmentDefinition
+	}
+
+	type output struct {
+		shouldErr bool
+	}
+
+	testCases := []struct {
+		name     string
+		given    input
+		expected output
+	}{
+		{
+			name: "ippool name different from nad name with the nad properly labeled",
+			given: input{
+				vmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig("", "", testNetworkName).Build(),
+				ipPool: newTestIPPoolBuilder().
+					NetworkName(testNetworkName).Build(),
+				nad: newTestNetworkAttachmentDefinitionBuilder().
+					Label(util.IPPoolNamespaceLabelKey, testIPPoolNamespace).
+					Label(util.IPPoolNameLabelKey, testIPPoolName).Build(),
+			},
+			expected: output{
+				shouldErr: false,
+			},
+		},
+		{
+			name: "ippool and nad share the same name with the nad properly labeled",
+			given: input{
+				vmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig("", "", testNetworkName).Build(),
+				ipPool: ippool.NewIPPoolBuilder(testNADNamespace, testNADName).
+					NetworkName(testNetworkName).Build(),
+				nad: newTestNetworkAttachmentDefinitionBuilder().
+					Label(util.IPPoolNamespaceLabelKey, testNADNamespace).
+					Label(util.IPPoolNameLabelKey, testNADName).Build(),
+			},
+			expected: output{
+				shouldErr: false,
+			},
+		},
+		{
+			name: "non-existed ippool referenced",
+			given: input{
+				vmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig("", "", testNetworkName).Build(),
+				nad: newTestNetworkAttachmentDefinitionBuilder().
+					Label(util.IPPoolNamespaceLabelKey, testIPPoolNamespace).
+					Label(util.IPPoolNameLabelKey, testIPPoolName).Build(),
+			},
+			expected: output{
+				shouldErr: true,
+			},
+		},
+		{
+			name: "non-existed nad referenced",
+			given: input{
+				vmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig("", "", testNetworkName).Build(),
+				ipPool: newTestIPPoolBuilder().
+					NetworkName(testNetworkName).Build(),
+			},
+			expected: output{
+				shouldErr: true,
+			},
+		},
+		{
+			name: "nad referenced does not have proper labels to associate with the target ippool",
+			given: input{
+				vmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig("", "", testNetworkName).Build(),
+				ipPool: newTestIPPoolBuilder().Build(),
+				nad:    newTestNetworkAttachmentDefinitionBuilder().Build(),
+			},
+			expected: output{
+				shouldErr: true,
+			},
+		},
+	}
+
+	nadGVR := schema.GroupVersionResource{
+		Group:    "k8s.cni.cncf.io",
+		Version:  "v1",
+		Resource: "network-attachment-definitions",
+	}
+
+	for _, tc := range testCases {
+		clientset := fake.NewSimpleClientset()
+		if tc.given.ipPool != nil {
+			err := clientset.Tracker().Add(tc.given.ipPool)
+			assert.NoError(t, err, "mock resource should add into fake controller tracker")
+		}
+		if tc.given.nad != nil {
+			err := clientset.Tracker().Create(nadGVR, tc.given.nad, tc.given.nad.Namespace)
+			assert.NoError(t, err, "mock resource should add into fake controller tracker")
+		}
+
+		ipPoolCache := fakeclient.IPPoolCache(clientset.NetworkV1alpha1().IPPools)
+		nadCache := fakeclient.NetworkAttachmentDefinitionCache(clientset.K8sCniCncfIoV1().NetworkAttachmentDefinitions)
+		validator := NewValidator(ipPoolCache, nadCache)
+
+		err := validator.Create(&admission.Request{}, tc.given.vmNetCfg)
+		assert.Equal(t, tc.expected.shouldErr, err != nil, tc.name)
+	}
+}

--- a/pkg/webhook/vmnetcfg/validator_test.go
+++ b/pkg/webhook/vmnetcfg/validator_test.go
@@ -121,6 +121,19 @@ func TestValidator_Create(t *testing.T) {
 				shouldErr: true,
 			},
 		},
+		{
+			name: "nad referenced has incomplete labels set to associate with the target ippool",
+			given: input{
+				vmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig("", "", testNetworkName).Build(),
+				ipPool: newTestIPPoolBuilder().Build(),
+				nad: newTestNetworkAttachmentDefinitionBuilder().
+					Label(util.IPPoolNameLabelKey, testIPPoolName).Build(),
+			},
+			expected: output{
+				shouldErr: true,
+			},
+		},
 	}
 
 	nadGVR := schema.GroupVersionResource{


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

If the name of the IPPool CR is not the same as its associated NetworkAttachmentDefinition (NAD) CR, all the VirtualMachineNetworkConfig (vmnetcfg) CR referencing the IPPool cannot be created automatically by the controller.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Fix the vmnetcfg validating webhook logic.

**Related Issue:**

harvester/harvester#9710

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Create a single-node v1.7.0 Harvester cluster
2. Enable the Managed DHCP add-on using the following manifest:
   ```yaml
   apiVersion: harvesterhci.io/v1beta1
   kind: Addon
   metadata:
     name: harvester-vm-dhcp-controller
     namespace: harvester-system
     labels:
       addon.harvesterhci.io/experimental: "true"
   spec:
     enabled: true
     repo: https://charts.harvesterhci.io
     version: 1.6.0
     chart: harvester-vm-dhcp-controller
     valuesContent: |
       image:
         repository: starbops/harvester-vm-dhcp-controller
         tag: pool-name-hot-fix-head
       webhook:
         image:
           repository: starbops/harvester-vm-dhcp-webhook
           tag: pool-name-hot-fix-head
       agent:
         image:
           repository: starbops/harvester-vm-dhcp-agent
           tag: pool-name-hot-fix-head
   ```
3. Create a Virtual Machine Network (NAD) called `test-net`
4. Create an IPPool called `test-pool` (the name must be different from its associated NAD's name)
   ```yaml
   apiVersion: network.harvesterhci.io/v1alpha1
   kind: IPPool
   metadata:
     name: test-pool
   spec:
    ipv4Config:
      cidr: 192.168.48.0/24   # please change the cidr accordingly to suit your network environment
      router: 192.168.48.254  # required if you need qemu-guest-agent installed via internet
    networkName: default/test-net
   ```
6. Create a virtual machine `test-vm` and attach it to the `test-net` NAD
7. The virtual machine should eventually get the allocated IP address (it should match the one reflected in the VirtualMachineNetworkConfig CR)
