### PR TITLE
ci: update trivy scan workflow with VEX support

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -2,28 +2,37 @@ name: trivy-scanning
 on:
   push:
     branches:
-    - main
-    - v*
+      - main
+      - "v*"
   pull_request:
 
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-    - name: Run Trivy vulnerability scanner in repo mode
-      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
-      with:
-        scan-type: 'fs'
-        ignore-unfixed: true
-        format: 'sarif'
-        output: 'trivy-results.sarif'
-        severity: 'CRITICAL'
+      - name: Download Rancher's VEX Hub report
+        run: |
+          curl -fsSL -H "Accept: application/vnd.git-lfs+json" \
+            "https://media.githubusercontent.com/media/rancher/vexhub/main/reports/rancher.openvex.json" \
+            -o rancher.openvex.json
 
-    - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3 # v3
-      with:
-        sarif_file: 'trivy-results.sarif'
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          scan-type: "fs"
+          ignore-unfixed: true
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH,MEDIUM"
+        env:
+          TRIVY_VEX: rancher.openvex.json
+          TRIVY_SHOW_SUPPRESSED: true
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3 # v3.34.1
+        with:
+          sarif_file: "trivy-results.sarif"


### PR DESCRIPTION
## Summary
- update the Trivy GitHub Actions workflow
- download Rancher VEX Hub report before scanning
- pass VEX data to Trivy and show suppressed findings
- add DCO signoff to the commit

## Testing
- not run (GitHub Actions change only)