### PR TITLE
chore: bump go 1.26

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,11 +1,11 @@
-FROM registry.suse.com/bci/golang:1.25.7
+FROM registry.suse.com/bci/golang:1.26
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH=$DAPPER_HOST_ARCH
 
 RUN zypper -n install tar gzip bash git docker less file curl wget
 
-COPY --from=golangci/golangci-lint:v2.11.4-alpine@sha256:72bcd68512b4e27540dd3a778a1b7afd45759d8145cfb3c089f1d7af53e718e9 /usr/bin/golangci-lint /usr/local/bin/golangci-lint
+COPY --from=golangci/golangci-lint:v2.12.2-alpine@sha256:91b27804074a0bacea298707f016911e60cf0cdbc6c7bf5ccacb5f0606d18d60 /usr/bin/golangci-lint /usr/local/bin/golangci-lint
 
 ## install controller-gen
 RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.18.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/vm-dhcp-controller
 
-go 1.25.7
+go 1.26
 
 replace (
 	github.com/google/gnostic-models => github.com/google/gnostic-models v0.6.9


### PR DESCRIPTION
    - also bump golangci-lint 2.12.2

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
bump go 1.26

**Solution:**
bump go 1.26

**Related Issue:**
https://github.com/harvester/harvester/issues/10734

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
