### PR TITLE
Support static IP assignment via VM annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,41 @@ metadata:
   namespace: default
 spec:
   vmName: test-vm
-  networkConfig:
+  networkConfigs:
   - macAddress: fa:cf:8e:50:82:fc
     networkName: default/net-48
 EOF
 ```
+
+### Static IPs from VM annotations
+
+For Harvester-created VMs, a desired DHCP lease can be pinned per NIC by adding
+annotations to the VirtualMachine:
+
+```
+metadata:
+  annotations:
+    static-ip.harvesterhci.io/nic-1: "192.168.48.86"
+    static-ip.harvesterhci.io/nic-2: "192.168.48.87"
+```
+
+The suffix after `static-ip.harvesterhci.io/` must match the VM interface name
+under `spec.template.spec.domain.devices.interfaces[].name`. The controller
+copies the requested address into the generated VirtualMachineNetworkConfig
+`spec.networkConfigs[].ipAddress`, and the DHCP agent serves that IP through
+the normal IPPool lease flow.
+
+Changing the annotation on an existing VM deallocates the old IP and pins the
+MAC to the new requested IP on the next reconciliation. Removing the annotation
+keeps the current allocation and returns that NIC to dynamic allocation for
+future changes. Harvester normally provides a MAC address for each interface; if
+no MAC can be resolved for a NIC, that NIC is skipped. The vmnetcfg webhook
+rejects invalid requested IPs where possible, which can appear as a denied API
+request in the vm controller logs before a VirtualMachineNetworkConfig is
+created. Allocation-time failures after the object exists are reported on the
+VirtualMachineNetworkConfig `Allocated` condition. Because removing the
+annotation keeps the current allocation, that IP cannot be requested by another
+VM until the old VirtualMachineNetworkConfig allocation is removed or changes.
 
 ## Observability
 

--- a/pkg/controller/vm/common.go
+++ b/pkg/controller/vm/common.go
@@ -2,13 +2,14 @@ package vm
 
 import (
 	"encoding/json"
+	"sort"
 
+	harvesterutil "github.com/harvester/harvester/pkg/util"
+	networkv1 "github.com/harvester/vm-dhcp-controller/pkg/apis/network.harvesterhci.io/v1alpha1"
+	dhcputil "github.com/harvester/vm-dhcp-controller/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	kubevirtv1 "kubevirt.io/api/core/v1"
-
-	"github.com/harvester/harvester/pkg/util"
-	networkv1 "github.com/harvester/vm-dhcp-controller/pkg/apis/network.harvesterhci.io/v1alpha1"
 )
 
 func prepareVmNetCfg(vm *kubevirtv1.VirtualMachine, ncm map[string]networkv1.NetworkConfig) *networkv1.VirtualMachineNetworkConfig {
@@ -17,8 +18,13 @@ func prepareVmNetCfg(vm *kubevirtv1.VirtualMachine, ncm map[string]networkv1.Net
 	}
 
 	ncs := make([]networkv1.NetworkConfig, 0, len(ncm))
-	for _, nc := range ncm {
-		ncs = append(ncs, nc)
+	nicNames := make([]string, 0, len(ncm))
+	for nicName := range ncm {
+		nicNames = append(nicNames, nicName)
+	}
+	sort.Strings(nicNames)
+	for _, nicName := range nicNames {
+		ncs = append(ncs, ncm[nicName])
 	}
 
 	return &networkv1.VirtualMachineNetworkConfig{
@@ -67,7 +73,16 @@ func (b *vmBuilder) WithInterfaceInAnnotation(macAddress, nicName string) *vmBui
 	}
 
 	macAddressBytes, _ := json.Marshal(b.nicToMacAddress)
-	b.vm.Annotations[util.AnnotationMacAddressName] = string(macAddressBytes)
+	b.vm.Annotations[harvesterutil.AnnotationMacAddressName] = string(macAddressBytes)
+	return b
+}
+
+func (b *vmBuilder) WithStaticIPAnnotation(nicName, ipAddress string) *vmBuilder {
+	if b.vm.Annotations == nil {
+		b.vm.Annotations = make(map[string]string)
+	}
+
+	b.vm.Annotations[dhcputil.StaticIPAnnotationPrefix+nicName] = ipAddress
 	return b
 }
 

--- a/pkg/controller/vm/controller.go
+++ b/pkg/controller/vm/controller.go
@@ -3,9 +3,11 @@ package vm
 import (
 	"context"
 	"encoding/json"
+	"net"
 	"reflect"
+	"strings"
 
-	"github.com/harvester/harvester/pkg/util"
+	harvesterutil "github.com/harvester/harvester/pkg/util"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -15,6 +17,7 @@ import (
 	"github.com/harvester/vm-dhcp-controller/pkg/config"
 	ctlkubevirtv1 "github.com/harvester/vm-dhcp-controller/pkg/generated/controllers/kubevirt.io/v1"
 	ctlnetworkv1 "github.com/harvester/vm-dhcp-controller/pkg/generated/controllers/network.harvesterhci.io/v1alpha1"
+	dhcputil "github.com/harvester/vm-dhcp-controller/pkg/util"
 )
 
 const (
@@ -58,13 +61,13 @@ func (h *Handler) OnChange(key string, vm *kubevirtv1.VirtualMachine) (*kubevirt
 	ncm := make(map[string]networkv1.NetworkConfig, 1)
 
 	// Construct initial network config map from annotation
-	if vm.Annotations != nil && vm.Annotations[util.AnnotationMacAddressName] != "" {
+	if vm.Annotations != nil && vm.Annotations[harvesterutil.AnnotationMacAddressName] != "" {
 		nicToMacAddress := map[string]string{}
-		if err := json.Unmarshal([]byte(vm.Annotations[util.AnnotationMacAddressName]), &nicToMacAddress); err != nil {
+		if err := json.Unmarshal([]byte(vm.Annotations[harvesterutil.AnnotationMacAddressName]), &nicToMacAddress); err != nil {
 			logrus.WithError(err).WithFields(logrus.Fields{
 				"name":      vm.Name,
 				"namespace": vm.Namespace,
-				"macs":      vm.Annotations[util.AnnotationMacAddressName],
+				"macs":      vm.Annotations[harvesterutil.AnnotationMacAddressName],
 			}).Error("failed to unmarshal mac-address from vm annotation")
 			return nil, nil
 		}
@@ -107,6 +110,8 @@ func (h *Handler) OnChange(key string, vm *kubevirtv1.VirtualMachine) (*kubevirt
 			delete(ncm, i)
 		}
 	}
+
+	applyStaticIPAnnotations(vm, ncm)
 
 	// If no network config is found, return early
 	if len(ncm) == 0 {
@@ -163,4 +168,42 @@ func (h *Handler) OnChange(key string, vm *kubevirtv1.VirtualMachine) (*kubevirt
 	}
 
 	return vm, nil
+}
+
+func applyStaticIPAnnotations(vm *kubevirtv1.VirtualMachine, ncm map[string]networkv1.NetworkConfig) {
+	if len(vm.Annotations) == 0 {
+		return
+	}
+
+	for key, ipAddress := range vm.Annotations {
+		if !strings.HasPrefix(key, dhcputil.StaticIPAnnotationPrefix) {
+			continue
+		}
+
+		nicName := strings.TrimPrefix(key, dhcputil.StaticIPAnnotationPrefix)
+		nc, ok := ncm[nicName]
+		if nicName == "" || !ok {
+			logrus.WithFields(logrus.Fields{
+				"name":       vm.Name,
+				"namespace":  vm.Namespace,
+				"annotation": key,
+			}).Warn("static ip annotation references unknown nic")
+			continue
+		}
+
+		ip := net.ParseIP(ipAddress)
+		if ip == nil || ip.To4() == nil {
+			logrus.WithFields(logrus.Fields{
+				"name":       vm.Name,
+				"namespace":  vm.Namespace,
+				"annotation": key,
+				"ip":         ipAddress,
+			}).Warn("static ip annotation value is not a valid IPv4 address")
+			continue
+		}
+
+		normalizedIP := ip.To4().String()
+		nc.IPAddress = &normalizedIP
+		ncm[nicName] = nc
+	}
 }

--- a/pkg/controller/vm/controller_test.go
+++ b/pkg/controller/vm/controller_test.go
@@ -25,7 +25,9 @@ const (
 	testMACAddress1       = "11:22:33:44:55:66"
 	testMACAddress2       = "22:33:44:55:66:77"
 	testIPAddress         = "192.168.100.100"
+	testIPAddress2        = "192.168.100.101"
 	testNICName           = "nic1"
+	testNICName2          = "nic2"
 	testVmNetCfgNamespace = "default"
 	testVmNetCfgName      = "test-vm"
 )
@@ -107,6 +109,142 @@ func TestHandler_OnChange(t *testing.T) {
 			}).
 			WithVMName(testVMName).
 			WithNetworkConfig("", testMACAddress1, testNetworkName).Build()
+
+		clientset := fake.NewSimpleClientset()
+		err := clientset.Tracker().Add(givenVM)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		handler := Handler{
+			vmnetcfgCache:  fakeclient.VirtualMachineNetworkConfigCache(clientset.NetworkV1alpha1().VirtualMachineNetworkConfigs),
+			vmnetcfgClient: fakeclient.VirtualMachineNetworkConfigClient(clientset.NetworkV1alpha1().VirtualMachineNetworkConfigs),
+		}
+
+		_, err = handler.OnChange(testKey, givenVM)
+		assert.Nil(t, err)
+
+		vmNetCfg, err := handler.vmnetcfgClient.Get(testVmNetCfgNamespace, testVmNetCfgName, metav1.GetOptions{})
+		assert.Nil(t, err)
+		assert.Equal(t, expectedVmNetCfg, vmNetCfg)
+	})
+
+	t.Run("new vm with static ip annotation", func(t *testing.T) {
+		givenVM := newTestVMBuilder().
+			WithInterfaceInSpec(testMACAddress1, testNICName).
+			WithNetwork(testNICName, testNetworkName).
+			WithStaticIPAnnotation(testNICName, testIPAddress).Build()
+
+		expectedVmNetCfg := newTestVmNetCfgBuilder().
+			Label(vmLabelKey, testVMName).
+			OwnerRef(metav1.OwnerReference{
+				Name: testVMName,
+			}).
+			WithVMName(testVMName).
+			WithNetworkConfig(testIPAddress, testMACAddress1, testNetworkName).Build()
+
+		clientset := fake.NewSimpleClientset()
+		err := clientset.Tracker().Add(givenVM)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		handler := Handler{
+			vmnetcfgCache:  fakeclient.VirtualMachineNetworkConfigCache(clientset.NetworkV1alpha1().VirtualMachineNetworkConfigs),
+			vmnetcfgClient: fakeclient.VirtualMachineNetworkConfigClient(clientset.NetworkV1alpha1().VirtualMachineNetworkConfigs),
+		}
+
+		_, err = handler.OnChange(testKey, givenVM)
+		assert.Nil(t, err)
+
+		vmNetCfg, err := handler.vmnetcfgClient.Get(testVmNetCfgNamespace, testVmNetCfgName, metav1.GetOptions{})
+		assert.Nil(t, err)
+		assert.Equal(t, expectedVmNetCfg, vmNetCfg)
+	})
+
+	t.Run("new vm ignores static ip annotation for unknown nic", func(t *testing.T) {
+		givenVM := newTestVMBuilder().
+			WithInterfaceInSpec(testMACAddress1, testNICName).
+			WithNetwork(testNICName, testNetworkName).
+			WithStaticIPAnnotation("unknown-nic", testIPAddress).Build()
+
+		expectedVmNetCfg := newTestVmNetCfgBuilder().
+			Label(vmLabelKey, testVMName).
+			OwnerRef(metav1.OwnerReference{
+				Name: testVMName,
+			}).
+			WithVMName(testVMName).
+			WithNetworkConfig("", testMACAddress1, testNetworkName).Build()
+
+		clientset := fake.NewSimpleClientset()
+		err := clientset.Tracker().Add(givenVM)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		handler := Handler{
+			vmnetcfgCache:  fakeclient.VirtualMachineNetworkConfigCache(clientset.NetworkV1alpha1().VirtualMachineNetworkConfigs),
+			vmnetcfgClient: fakeclient.VirtualMachineNetworkConfigClient(clientset.NetworkV1alpha1().VirtualMachineNetworkConfigs),
+		}
+
+		_, err = handler.OnChange(testKey, givenVM)
+		assert.Nil(t, err)
+
+		vmNetCfg, err := handler.vmnetcfgClient.Get(testVmNetCfgNamespace, testVmNetCfgName, metav1.GetOptions{})
+		assert.Nil(t, err)
+		assert.Equal(t, expectedVmNetCfg, vmNetCfg)
+	})
+
+	t.Run("new vm ignores malformed static ip annotation", func(t *testing.T) {
+		givenVM := newTestVMBuilder().
+			WithInterfaceInSpec(testMACAddress1, testNICName).
+			WithNetwork(testNICName, testNetworkName).
+			WithStaticIPAnnotation(testNICName, "not-an-ip").Build()
+
+		expectedVmNetCfg := newTestVmNetCfgBuilder().
+			Label(vmLabelKey, testVMName).
+			OwnerRef(metav1.OwnerReference{
+				Name: testVMName,
+			}).
+			WithVMName(testVMName).
+			WithNetworkConfig("", testMACAddress1, testNetworkName).Build()
+
+		clientset := fake.NewSimpleClientset()
+		err := clientset.Tracker().Add(givenVM)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		handler := Handler{
+			vmnetcfgCache:  fakeclient.VirtualMachineNetworkConfigCache(clientset.NetworkV1alpha1().VirtualMachineNetworkConfigs),
+			vmnetcfgClient: fakeclient.VirtualMachineNetworkConfigClient(clientset.NetworkV1alpha1().VirtualMachineNetworkConfigs),
+		}
+
+		_, err = handler.OnChange(testKey, givenVM)
+		assert.Nil(t, err)
+
+		vmNetCfg, err := handler.vmnetcfgClient.Get(testVmNetCfgNamespace, testVmNetCfgName, metav1.GetOptions{})
+		assert.Nil(t, err)
+		assert.Equal(t, expectedVmNetCfg, vmNetCfg)
+	})
+
+	t.Run("new vm maps static ip annotations to matching nics", func(t *testing.T) {
+		givenVM := newTestVMBuilder().
+			WithInterfaceInSpec(testMACAddress1, testNICName).
+			WithInterfaceInSpec(testMACAddress2, testNICName2).
+			WithNetwork(testNICName, testNetworkName).
+			WithNetwork(testNICName2, testNetworkName).
+			WithStaticIPAnnotation(testNICName, testIPAddress).
+			WithStaticIPAnnotation(testNICName2, testIPAddress2).Build()
+
+		expectedVmNetCfg := newTestVmNetCfgBuilder().
+			Label(vmLabelKey, testVMName).
+			OwnerRef(metav1.OwnerReference{
+				Name: testVMName,
+			}).
+			WithVMName(testVMName).
+			WithNetworkConfig(testIPAddress, testMACAddress1, testNetworkName).
+			WithNetworkConfig(testIPAddress2, testMACAddress2, testNetworkName).Build()
 
 		clientset := fake.NewSimpleClientset()
 		err := clientset.Tracker().Add(givenVM)
@@ -255,6 +393,49 @@ func TestHandler_OnChange(t *testing.T) {
 		vmNetCfg, err := handler.vmnetcfgClient.Get(testVmNetCfgNamespace, testVmNetCfgName, metav1.GetOptions{})
 		assert.Nil(t, err)
 		// The InSynced condition is the only thing we care about in this test
+		assert.Equal(t, expectedVmNetCfg.Status, vmNetCfg.Status)
+	})
+
+	t.Run("static ip annotation change should flag existing vmnetcfg as out-of-sync", func(t *testing.T) {
+		givenVM := newTestVMBuilder().
+			WithInterfaceInSpec(testMACAddress1, testNICName).
+			WithNetwork(testNICName, testNetworkName).
+			WithStaticIPAnnotation(testNICName, testIPAddress2).Build()
+		givenVmNetCfg := newTestVmNetCfgBuilder().
+			Label(vmLabelKey, testVMName).
+			WithVMName(testVMName).
+			WithNetworkConfig(testIPAddress, testMACAddress1, testNetworkName).
+			WithNetworkConfigStatus(testIPAddress, testMACAddress1, testNetworkName, networkv1.AllocatedState).
+			InSyncedCondition(corev1.ConditionTrue, "", "").Build()
+
+		expectedVmNetCfg := newTestVmNetCfgBuilder().
+			Label(vmLabelKey, testVMName).
+			WithVMName(testVMName).
+			WithNetworkConfig(testIPAddress, testMACAddress1, testNetworkName).
+			WithNetworkConfigStatus(testIPAddress, testMACAddress1, testNetworkName, networkv1.AllocatedState).
+			InSyncedCondition(corev1.ConditionFalse, "NetworkConfigChanged", "Network configuration of the upstrem virtual machine has been changed").Build()
+
+		clientset := fake.NewSimpleClientset()
+		err := clientset.Tracker().Add(givenVM)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = clientset.Tracker().Add(givenVmNetCfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		handler := Handler{
+			vmController:   fakecontroller.VirtualMachineController(clientset.KubevirtV1().VirtualMachines),
+			vmnetcfgCache:  fakeclient.VirtualMachineNetworkConfigCache(clientset.NetworkV1alpha1().VirtualMachineNetworkConfigs),
+			vmnetcfgClient: fakeclient.VirtualMachineNetworkConfigClient(clientset.NetworkV1alpha1().VirtualMachineNetworkConfigs),
+		}
+
+		_, err = handler.OnChange(testKey, givenVM)
+		assert.Nil(t, err)
+
+		vmNetCfg, err := handler.vmnetcfgClient.Get(testVmNetCfgNamespace, testVmNetCfgName, metav1.GetOptions{})
+		assert.Nil(t, err)
 		assert.Equal(t, expectedVmNetCfg.Status, vmNetCfg.Status)
 	})
 

--- a/pkg/controller/vmnetcfg/controller.go
+++ b/pkg/controller/vmnetcfg/controller.go
@@ -146,14 +146,15 @@ func (h *Handler) Allocate(vmNetCfg *networkv1.VirtualMachineNetworkConfig, stat
 			if err != nil {
 				return status, err
 			}
+			if nc.IPAddress != nil && *nc.IPAddress != ip {
+				return status, fmt.Errorf("desired IP changed for mac %s from %s to %s; waiting for sync", nc.MACAddress, ip, *nc.IPAddress)
+			}
 		} else {
 			dIP := net.IPv4zero.String()
 			if nc.IPAddress != nil {
 				dIP = *nc.IPAddress
-			}
-
-			// Recover IP from status (resume from paused state)
-			if oIP, err := findIPAddressFromNetworkConfigStatusByMACAddress(vmNetCfg.Status.NetworkConfigs, nc.MACAddress); err == nil {
+			} else if oIP, err := findIPAddressFromNetworkConfigStatusByMACAddress(vmNetCfg.Status.NetworkConfigs, nc.MACAddress); err == nil {
+				// Recover IP from status (resume from paused state)
 				dIP = oIP
 			}
 
@@ -242,16 +243,24 @@ func (h *Handler) Sync(vmNetCfg *networkv1.VirtualMachineNetworkConfig, status n
 	logrus.Infof("(vmnetcfg.InSynced) vmnetcfg %s/%s is out-of-sync; start reconciling", vmNetCfg.Namespace, vmNetCfg.Name)
 
 	// Build a set of MAC addresses from the Spec
-	var macAddressSet = make(map[string]struct{})
+	var desiredIPByNetworkConfig = make(map[util.NetworkConfigKey]*string)
 	for _, nc := range vmNetCfg.Spec.NetworkConfigs {
-		macAddressSet[nc.MACAddress] = struct{}{}
+		desiredIPByNetworkConfig[util.NetworkConfigKey{
+			NetworkName: nc.NetworkName,
+			MACAddress:  nc.MACAddress,
+		}] = nc.IPAddress
 	}
 
-	// Mark the NetworkConfigStatus as stale if the MAC address is not in
-	// the Spec; otherwise, add it to the non-stale list.
+	// Mark the NetworkConfigStatus as stale if the network config is not in
+	// the Spec or its explicit desired IP changed; otherwise, add it to the
+	// non-stale list.
 	var nonStaleNetworkConfigs []networkv1.NetworkConfigStatus
 	for i, ncStatus := range status.NetworkConfigs {
-		if _, ok := macAddressSet[ncStatus.MACAddress]; !ok {
+		desiredIP, ok := desiredIPByNetworkConfig[util.NetworkConfigKey{
+			NetworkName: ncStatus.NetworkName,
+			MACAddress:  ncStatus.MACAddress,
+		}]
+		if !ok || (desiredIP != nil && *desiredIP != ncStatus.AllocatedIPAddress) {
 			status.NetworkConfigs[i].State = networkv1.StaleState
 			continue
 		}

--- a/pkg/controller/vmnetcfg/controller_test.go
+++ b/pkg/controller/vmnetcfg/controller_test.go
@@ -425,6 +425,105 @@ func TestHandler_Allocate(t *testing.T) {
 		assert.Equal(t, expectedIPPool, ipPool)
 	})
 
+	t.Run("cache hit with changed desired ip should wait for sync", func(t *testing.T) {
+		givenVmNetCfg := newTestVmNetCfgBuilder().
+			WithNetworkConfig(testIPAddress2, testMACAddress1, testNetworkName).Build()
+		givenIPPool := newTestIPPoolBuilder().
+			ServerIP(testServerIP).
+			CIDR(testCIDR).
+			PoolRange(testStartIP, testEndIP).
+			NetworkName(testNetworkName).
+			CacheReadyCondition(corev1.ConditionTrue, "", "").Build()
+		givenCacheAllocator := newTestCacheAllocatorBuilder().
+			MACSet(testNetworkName).
+			Add(testNetworkName, testMACAddress1, testIPAddress1).Build()
+		givenNAD := newTestNetworkAttachmentDefinitionBuilder().
+			Label(util.IPPoolNamespaceLabelKey, testIPPoolNamespace).
+			Label(util.IPPoolNameLabelKey, testIPPoolName).Build()
+
+		nadGVR := schema.GroupVersionResource{
+			Group:    "k8s.cni.cncf.io",
+			Version:  "v1",
+			Resource: "network-attachment-definitions",
+		}
+
+		clientset := fake.NewSimpleClientset()
+		err := clientset.Tracker().Create(nadGVR, givenNAD, givenNAD.Namespace)
+		assert.Nil(t, err, "mock resource should add into fake controller tracker")
+
+		err = clientset.Tracker().Add(givenIPPool)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		handler := Handler{
+			cacheAllocator: givenCacheAllocator,
+			ippoolClient:   fakeclient.IPPoolClient(clientset.NetworkV1alpha1().IPPools),
+			ippoolCache:    fakeclient.IPPoolCache(clientset.NetworkV1alpha1().IPPools),
+			nadCache:       fakeclient.NetworkAttachmentDefinitionCache(clientset.K8sCniCncfIoV1().NetworkAttachmentDefinitions),
+		}
+
+		_, err = handler.Allocate(givenVmNetCfg, givenVmNetCfg.Status)
+		assert.EqualError(t, err, fmt.Sprintf("desired IP changed for mac %s from %s to %s; waiting for sync", testMACAddress1, testIPAddress1, testIPAddress2))
+	})
+
+	t.Run("explicit desired ip should not be overridden by status recovery", func(t *testing.T) {
+		givenVmNetCfg := newTestVmNetCfgBuilder().
+			WithNetworkConfig(testIPAddress2, testMACAddress1, testNetworkName).
+			WithNetworkConfigStatus(testIPAddress1, testMACAddress1, testNetworkName, networkv1.AllocatedState).Build()
+		givenIPPool := newTestIPPoolBuilder().
+			ServerIP(testServerIP).
+			CIDR(testCIDR).
+			PoolRange(testStartIP, testEndIP).
+			NetworkName(testNetworkName).
+			CacheReadyCondition(corev1.ConditionTrue, "", "").Build()
+		givenCacheAllocator := newTestCacheAllocatorBuilder().
+			MACSet(testNetworkName).Build()
+		givenIPAllocator := newTestIPAllocatorBuilder().
+			IPSubnet(testNetworkName, testCIDR, testStartIP, testEndIP).Build()
+		givenNAD := newTestNetworkAttachmentDefinitionBuilder().
+			Label(util.IPPoolNamespaceLabelKey, testIPPoolNamespace).
+			Label(util.IPPoolNameLabelKey, testIPPoolName).Build()
+
+		expectedStatus := newTestVmNetCfgStatusBuilder().
+			WithNetworkConfigStatus(testIPAddress2, testMACAddress1, testNetworkName, networkv1.AllocatedState).Build()
+		expectedIPAllocator := newTestIPAllocatorBuilder().
+			IPSubnet(testNetworkName, testCIDR, testStartIP, testEndIP).
+			Allocate(testNetworkName, testIPAddress2).Build()
+
+		nadGVR := schema.GroupVersionResource{
+			Group:    "k8s.cni.cncf.io",
+			Version:  "v1",
+			Resource: "network-attachment-definitions",
+		}
+
+		clientset := fake.NewSimpleClientset()
+		err := clientset.Tracker().Create(nadGVR, givenNAD, givenNAD.Namespace)
+		assert.Nil(t, err, "mock resource should add into fake controller tracker")
+
+		err = clientset.Tracker().Add(givenIPPool)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		handler := Handler{
+			cacheAllocator:   givenCacheAllocator,
+			ipAllocator:      givenIPAllocator,
+			metricsAllocator: metrics.New(),
+			ippoolClient:     fakeclient.IPPoolClient(clientset.NetworkV1alpha1().IPPools),
+			ippoolCache:      fakeclient.IPPoolCache(clientset.NetworkV1alpha1().IPPools),
+			nadCache:         fakeclient.NetworkAttachmentDefinitionCache(clientset.K8sCniCncfIoV1().NetworkAttachmentDefinitions),
+		}
+
+		status, err := handler.Allocate(givenVmNetCfg, givenVmNetCfg.Status)
+		assert.Nil(t, err)
+
+		SanitizeStatus(&expectedStatus)
+		SanitizeStatus(&status)
+		assert.Equal(t, expectedStatus, status)
+		assert.Equal(t, expectedIPAllocator, handler.ipAllocator)
+	})
+
 	t.Run("ippool cache not ready", func(t *testing.T) {
 		givenVmNetCfg := newTestVmNetCfgBuilder().
 			WithNetworkConfig(testIPAddress1, testMACAddress1, testNetworkName).
@@ -832,6 +931,148 @@ func TestHandler_Sync(t *testing.T) {
 			ippoolClient:     fakeclient.IPPoolClient(clientset.NetworkV1alpha1().IPPools),
 			ippoolCache:      fakeclient.IPPoolCache(clientset.NetworkV1alpha1().IPPools),
 			nadCache:         fakeclient.NetworkAttachmentDefinitionCache(clientset.K8sCniCncfIoV1().NetworkAttachmentDefinitions),
+		}
+
+		status, err := handler.Sync(givenVmNetCfg, givenVmNetCfg.Status)
+		assert.Nil(t, err)
+
+		SanitizeStatus(&expectedStatus)
+		SanitizeStatus(&status)
+		assert.Equal(t, expectedStatus, status)
+
+		ipPool, err := handler.ippoolClient.Get(testIPPoolNamespace, testIPPoolName, metav1.GetOptions{})
+		assert.Nil(t, err)
+
+		ippool.SanitizeStatus(&expectedIPPool.Status)
+		ippool.SanitizeStatus(&ipPool.Status)
+		assert.Equal(t, expectedIPPool, ipPool)
+
+		assert.Equal(t, expectedIPAllocator, handler.ipAllocator)
+		assert.Equal(t, expectedCacheAllocator, handler.cacheAllocator)
+	})
+
+	t.Run("sync out-of-sync vmnetcfg with changed desired ip should remove stale allocation", func(t *testing.T) {
+		givenVmNetCfg := newTestVmNetCfgBuilder().
+			WithNetworkConfig(testIPAddress2, testMACAddress1, testNetworkName).
+			WithNetworkConfigStatus(testIPAddress1, testMACAddress1, testNetworkName, networkv1.AllocatedState).Build()
+		givenIPPool := newTestIPPoolBuilder().
+			ServerIP(testServerIP).
+			CIDR(testCIDR).
+			PoolRange(testStartIP, testEndIP).
+			NetworkName(testNetworkName).
+			Allocated(testIPAddress1, testMACAddress1).
+			CacheReadyCondition(corev1.ConditionTrue, "", "").Build()
+		givenCacheAllocator := newTestCacheAllocatorBuilder().
+			MACSet(testNetworkName).
+			Add(testNetworkName, testMACAddress1, testIPAddress1).Build()
+		givenIPAllocator := newTestIPAllocatorBuilder().
+			IPSubnet(testNetworkName, testCIDR, testStartIP, testEndIP).
+			Allocate(testNetworkName, testIPAddress1).Build()
+		givenNAD := newTestNetworkAttachmentDefinitionBuilder().
+			Label(util.IPPoolNamespaceLabelKey, testIPPoolNamespace).
+			Label(util.IPPoolNameLabelKey, testIPPoolName).Build()
+
+		expectedStatus := newTestVmNetCfgStatusBuilder().Build()
+		expectedIPPool := newTestIPPoolBuilder().
+			ServerIP(testServerIP).
+			CIDR(testCIDR).
+			PoolRange(testStartIP, testEndIP).
+			NetworkName(testNetworkName).
+			CacheReadyCondition(corev1.ConditionTrue, "", "").Build()
+		expectedIPPool.Status.IPv4 = &networkv1.IPv4Status{Allocated: map[string]string{}}
+		expectedCacheAllocator := newTestCacheAllocatorBuilder().
+			MACSet(testNetworkName).Build()
+		expectedIPAllocator := newTestIPAllocatorBuilder().
+			IPSubnet(testNetworkName, testCIDR, testStartIP, testEndIP).Build()
+
+		nadGVR := schema.GroupVersionResource{
+			Group:    "k8s.cni.cncf.io",
+			Version:  "v1",
+			Resource: "network-attachment-definitions",
+		}
+
+		clientset := fake.NewSimpleClientset()
+		err := clientset.Tracker().Create(nadGVR, givenNAD, givenNAD.Namespace)
+		assert.Nil(t, err, "mock resource should add into fake controller tracker")
+
+		err = clientset.Tracker().Add(givenVmNetCfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = clientset.Tracker().Add(givenIPPool)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		handler := Handler{
+			cacheAllocator:   givenCacheAllocator,
+			ipAllocator:      givenIPAllocator,
+			metricsAllocator: metrics.New(),
+			ippoolClient:     fakeclient.IPPoolClient(clientset.NetworkV1alpha1().IPPools),
+			ippoolCache:      fakeclient.IPPoolCache(clientset.NetworkV1alpha1().IPPools),
+			nadCache:         fakeclient.NetworkAttachmentDefinitionCache(clientset.K8sCniCncfIoV1().NetworkAttachmentDefinitions),
+		}
+
+		status, err := handler.Sync(givenVmNetCfg, givenVmNetCfg.Status)
+		assert.Nil(t, err)
+
+		SanitizeStatus(&expectedStatus)
+		SanitizeStatus(&status)
+		assert.Equal(t, expectedStatus, status)
+
+		ipPool, err := handler.ippoolClient.Get(testIPPoolNamespace, testIPPoolName, metav1.GetOptions{})
+		assert.Nil(t, err)
+
+		ippool.SanitizeStatus(&expectedIPPool.Status)
+		ippool.SanitizeStatus(&ipPool.Status)
+		assert.Equal(t, expectedIPPool, ipPool)
+
+		assert.Equal(t, expectedIPAllocator, handler.ipAllocator)
+		assert.Equal(t, expectedCacheAllocator, handler.cacheAllocator)
+	})
+
+	t.Run("sync out-of-sync vmnetcfg with removed desired ip should keep current allocation", func(t *testing.T) {
+		givenVmNetCfg := newTestVmNetCfgBuilder().
+			WithNetworkConfig("", testMACAddress1, testNetworkName).
+			WithNetworkConfigStatus(testIPAddress1, testMACAddress1, testNetworkName, networkv1.AllocatedState).Build()
+		givenIPPool := newTestIPPoolBuilder().
+			ServerIP(testServerIP).
+			CIDR(testCIDR).
+			PoolRange(testStartIP, testEndIP).
+			NetworkName(testNetworkName).
+			Allocated(testIPAddress1, testMACAddress1).
+			CacheReadyCondition(corev1.ConditionTrue, "", "").Build()
+		givenCacheAllocator := newTestCacheAllocatorBuilder().
+			MACSet(testNetworkName).
+			Add(testNetworkName, testMACAddress1, testIPAddress1).Build()
+		givenIPAllocator := newTestIPAllocatorBuilder().
+			IPSubnet(testNetworkName, testCIDR, testStartIP, testEndIP).
+			Allocate(testNetworkName, testIPAddress1).Build()
+
+		expectedStatus := newTestVmNetCfgStatusBuilder().
+			WithNetworkConfigStatus(testIPAddress1, testMACAddress1, testNetworkName, networkv1.AllocatedState).Build()
+		expectedIPPool := newTestIPPoolBuilder().
+			ServerIP(testServerIP).
+			CIDR(testCIDR).
+			PoolRange(testStartIP, testEndIP).
+			NetworkName(testNetworkName).
+			Allocated(testIPAddress1, testMACAddress1).
+			CacheReadyCondition(corev1.ConditionTrue, "", "").Build()
+		expectedCacheAllocator := newTestCacheAllocatorBuilder().
+			MACSet(testNetworkName).
+			Add(testNetworkName, testMACAddress1, testIPAddress1).Build()
+		expectedIPAllocator := newTestIPAllocatorBuilder().
+			IPSubnet(testNetworkName, testCIDR, testStartIP, testEndIP).
+			Allocate(testNetworkName, testIPAddress1).Build()
+
+		clientset := fake.NewSimpleClientset(givenVmNetCfg, givenIPPool)
+
+		handler := Handler{
+			cacheAllocator:   givenCacheAllocator,
+			ipAllocator:      givenIPAllocator,
+			metricsAllocator: metrics.New(),
+			ippoolClient:     fakeclient.IPPoolClient(clientset.NetworkV1alpha1().IPPools),
+			ippoolCache:      fakeclient.IPPoolCache(clientset.NetworkV1alpha1().IPPools),
 		}
 
 		status, err := handler.Sync(givenVmNetCfg, givenVmNetCfg.Status)

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -12,13 +12,19 @@ const (
 	ExcludedMark = "EXCLUDED"
 	ReservedMark = "RESERVED"
 
-	AgentSuffixName         = "agent"
-	NodeArgsAnnotationKey   = "rke2.io/node-args"
-	ServiceCIDRFlag         = "--service-cidr"
-	ManagementNodeLabelKey  = "node-role.kubernetes.io/control-plane"
-	IPPoolNamespaceLabelKey = network.GroupName + "/ippool-namespace"
-	IPPoolNameLabelKey      = network.GroupName + "/ippool-name"
+	AgentSuffixName          = "agent"
+	NodeArgsAnnotationKey    = "rke2.io/node-args"
+	ServiceCIDRFlag          = "--service-cidr"
+	ManagementNodeLabelKey   = "node-role.kubernetes.io/control-plane"
+	IPPoolNamespaceLabelKey  = network.GroupName + "/ippool-namespace"
+	IPPoolNameLabelKey       = network.GroupName + "/ippool-name"
+	StaticIPAnnotationPrefix = "static-ip.harvesterhci.io/"
 )
+
+type NetworkConfigKey struct {
+	NetworkName string
+	MACAddress  string
+}
 
 func agentConcatName(name ...string) string {
 	return strings.Join(append(name, AgentSuffixName), "-")

--- a/pkg/webhook/vmnetcfg/validator.go
+++ b/pkg/webhook/vmnetcfg/validator.go
@@ -2,6 +2,7 @@ package vmnetcfg
 
 import (
 	"fmt"
+	"net/netip"
 
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,36 +35,82 @@ func (v *Validator) Create(request *admission.Request, newObj runtime.Object) er
 	vmNetCfg := newObj.(*networkv1.VirtualMachineNetworkConfig)
 	logrus.Infof("create vmnetcfg %s/%s", vmNetCfg.Namespace, vmNetCfg.Name)
 
+	return v.validate(vmNetCfg, webhook.CreateErr)
+}
+
+func (v *Validator) Update(_ *admission.Request, oldObj, newObj runtime.Object) error {
+	vmNetCfg := newObj.(*networkv1.VirtualMachineNetworkConfig)
+	if vmNetCfg.DeletionTimestamp != nil {
+		return nil
+	}
+
+	logrus.Infof("update vmnetcfg %s/%s", vmNetCfg.Namespace, vmNetCfg.Name)
+
+	oldVmNetCfg, ok := oldObj.(*networkv1.VirtualMachineNetworkConfig)
+	if !ok || oldVmNetCfg == nil {
+		return v.validate(vmNetCfg, webhook.UpdateErr)
+	}
+
+	return v.validateUpdate(oldVmNetCfg, vmNetCfg, webhook.UpdateErr)
+}
+
+func (v *Validator) validate(vmNetCfg *networkv1.VirtualMachineNetworkConfig, errFormat string) error {
+	seenDesiredIPs := map[string]struct{}{}
+
 	for _, nc := range vmNetCfg.Spec.NetworkConfigs {
-		nadNamespace, nadName := kv.RSplit(nc.NetworkName, "/")
-		if nadNamespace == "" {
-			nadNamespace = "default"
-		}
-		nad, err := v.nadCache.Get(nadNamespace, nadName)
+		ipPool, networkName, err := v.getIPPoolFromNetworkConfig(nc)
 		if err != nil {
-			return fmt.Errorf(webhook.CreateErr, vmNetCfg.Kind, vmNetCfg.Namespace, vmNetCfg.Name, err)
+			return fmt.Errorf(errFormat, vmNetCfg.Kind, vmNetCfg.Namespace, vmNetCfg.Name, err)
 		}
-		ipPoolNamespace, ok := nad.Labels[util.IPPoolNamespaceLabelKey]
-		if !ok {
-			return fmt.Errorf(
-				webhook.CreateErr,
-				vmNetCfg.Kind,
-				vmNetCfg.Namespace,
-				vmNetCfg.Name,
-				fmt.Errorf("%s label not found", util.IPPoolNamespaceLabelKey),
-			)
+
+		if nc.IPAddress == nil {
+			continue
 		}
-		ipPoolName, ok := nad.Labels[util.IPPoolNameLabelKey]
-		if !ok {
-			return fmt.Errorf(
-				webhook.CreateErr,
-				vmNetCfg.Kind,
-				vmNetCfg.Namespace,
-				vmNetCfg.Name, fmt.Errorf("%s label not found", util.IPPoolNameLabelKey),
-			)
+
+		if err := validateDesiredIPAddress(nc, ipPool, networkName, seenDesiredIPs); err != nil {
+			return fmt.Errorf(errFormat, vmNetCfg.Kind, vmNetCfg.Namespace, vmNetCfg.Name, err)
 		}
-		if _, err := v.ippoolCache.Get(ipPoolNamespace, ipPoolName); err != nil {
-			return fmt.Errorf(webhook.CreateErr, vmNetCfg.Kind, vmNetCfg.Namespace, vmNetCfg.Name, err)
+	}
+
+	return nil
+}
+
+func (v *Validator) validateUpdate(
+	oldVmNetCfg, vmNetCfg *networkv1.VirtualMachineNetworkConfig,
+	errFormat string,
+) error {
+	oldNetworkConfigs := map[util.NetworkConfigKey]networkv1.NetworkConfig{}
+	for _, nc := range oldVmNetCfg.Spec.NetworkConfigs {
+		oldNetworkConfigs[networkConfigKeyFromNetworkConfig(nc)] = nc
+	}
+
+	seenDesiredIPs := map[string]struct{}{}
+	var networkConfigsToValidate []networkv1.NetworkConfig
+	for _, nc := range vmNetCfg.Spec.NetworkConfigs {
+		if nc.IPAddress == nil {
+			continue
+		}
+
+		if desiredIPAddressChanged(oldNetworkConfigs, nc) {
+			networkConfigsToValidate = append(networkConfigsToValidate, nc)
+			continue
+		}
+
+		ipAddr, err := netip.ParseAddr(*nc.IPAddress)
+		if err != nil {
+			continue
+		}
+		seenDesiredIPs[desiredIPSeenKey(normalizeNetworkName(nc.NetworkName), ipAddr.String())] = struct{}{}
+	}
+
+	for _, nc := range networkConfigsToValidate {
+		ipPool, networkName, err := v.getIPPoolFromNetworkConfig(nc)
+		if err != nil {
+			return fmt.Errorf(errFormat, vmNetCfg.Kind, vmNetCfg.Namespace, vmNetCfg.Name, err)
+		}
+
+		if err := validateDesiredIPAddress(nc, ipPool, networkName, seenDesiredIPs); err != nil {
+			return fmt.Errorf(errFormat, vmNetCfg.Kind, vmNetCfg.Namespace, vmNetCfg.Name, err)
 		}
 	}
 
@@ -79,6 +126,120 @@ func (v *Validator) Resource() admission.Resource {
 		ObjectType: &networkv1.VirtualMachineNetworkConfig{},
 		OperationTypes: []admissionregv1.OperationType{
 			admissionregv1.Create,
+			admissionregv1.Update,
 		},
 	}
+}
+
+func (v *Validator) getIPPoolFromNetworkConfig(nc networkv1.NetworkConfig) (*networkv1.IPPool, string, error) {
+	nadNamespace, nadName := kv.RSplit(nc.NetworkName, "/")
+	if nadNamespace == "" {
+		nadNamespace = "default"
+	}
+	networkName := nadNamespace + "/" + nadName
+
+	nad, err := v.nadCache.Get(nadNamespace, nadName)
+	if err != nil {
+		return nil, networkName, err
+	}
+
+	ipPoolNamespace, ok := nad.Labels[util.IPPoolNamespaceLabelKey]
+	if !ok {
+		return nil, networkName, fmt.Errorf("%s label not found", util.IPPoolNamespaceLabelKey)
+	}
+	ipPoolName, ok := nad.Labels[util.IPPoolNameLabelKey]
+	if !ok {
+		return nil, networkName, fmt.Errorf("%s label not found", util.IPPoolNameLabelKey)
+	}
+
+	ipPool, err := v.ippoolCache.Get(ipPoolNamespace, ipPoolName)
+	return ipPool, networkName, err
+}
+
+func networkConfigKeyFromNetworkConfig(nc networkv1.NetworkConfig) util.NetworkConfigKey {
+	return util.NetworkConfigKey{
+		NetworkName: normalizeNetworkName(nc.NetworkName),
+		MACAddress:  nc.MACAddress,
+	}
+}
+
+func normalizeNetworkName(networkName string) string {
+	nadNamespace, nadName := kv.RSplit(networkName, "/")
+	if nadNamespace == "" {
+		nadNamespace = "default"
+	}
+	return nadNamespace + "/" + nadName
+}
+
+func desiredIPAddressChanged(oldNetworkConfigs map[util.NetworkConfigKey]networkv1.NetworkConfig, nc networkv1.NetworkConfig) bool {
+	oldNC, ok := oldNetworkConfigs[networkConfigKeyFromNetworkConfig(nc)]
+	if !ok {
+		return true
+	}
+	if oldNC.IPAddress == nil || nc.IPAddress == nil {
+		return oldNC.IPAddress != nc.IPAddress
+	}
+	return *oldNC.IPAddress != *nc.IPAddress
+}
+
+func desiredIPSeenKey(networkName, ipAddress string) string {
+	return networkName + "/" + ipAddress
+}
+
+func validateDesiredIPAddress(
+	nc networkv1.NetworkConfig,
+	ipPool *networkv1.IPPool,
+	networkName string,
+	seenDesiredIPs map[string]struct{},
+) error {
+	ipAddr, err := netip.ParseAddr(*nc.IPAddress)
+	if err != nil {
+		return err
+	}
+	if !ipAddr.Is4() {
+		return fmt.Errorf("ip address %s is not an IPv4 address", *nc.IPAddress)
+	}
+
+	seenKey := desiredIPSeenKey(networkName, ipAddr.String())
+	if _, ok := seenDesiredIPs[seenKey]; ok {
+		return fmt.Errorf("duplicate desired ip %s on network %s", ipAddr, networkName)
+	}
+	seenDesiredIPs[seenKey] = struct{}{}
+
+	poolInfo, err := util.LoadPool(ipPool)
+	if err != nil {
+		return err
+	}
+
+	if !poolInfo.IPNet.Contains(ipAddr.AsSlice()) {
+		return fmt.Errorf("ip address %s is not within subnet %s", ipAddr, ipPool.Spec.IPv4Config.CIDR)
+	}
+	if poolInfo.StartIPAddr.IsValid() && ipAddr.Compare(poolInfo.StartIPAddr) < 0 ||
+		poolInfo.EndIPAddr.IsValid() && ipAddr.Compare(poolInfo.EndIPAddr) > 0 {
+		return fmt.Errorf("ip address %s is not within pool range %s-%s", ipAddr, poolInfo.StartIPAddr, poolInfo.EndIPAddr)
+	}
+	if ipAddr == poolInfo.NetworkIPAddr {
+		return fmt.Errorf("ip address %s is the same as network ip", ipAddr)
+	}
+	if ipAddr == poolInfo.BroadcastIPAddr {
+		return fmt.Errorf("ip address %s is the same as broadcast ip", ipAddr)
+	}
+
+	if ipPool.Status.IPv4 == nil {
+		return nil
+	}
+	macAddress, ok := ipPool.Status.IPv4.Allocated[ipAddr.String()]
+	if !ok {
+		return nil
+	}
+	switch macAddress {
+	case util.ExcludedMark, util.ReservedMark:
+		return fmt.Errorf("ip address %s is not allocatable", ipAddr)
+	default:
+		if macAddress != nc.MACAddress {
+			return fmt.Errorf("ip address %s is already allocated to mac %s", ipAddr, macAddress)
+		}
+	}
+
+	return nil
 }

--- a/pkg/webhook/vmnetcfg/validator_test.go
+++ b/pkg/webhook/vmnetcfg/validator_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/harvester/webhook/pkg/server/admission"
 	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/stretchr/testify/assert"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	networkv1 "github.com/harvester/vm-dhcp-controller/pkg/apis/network.harvesterhci.io/v1alpha1"
@@ -24,6 +25,15 @@ const (
 	testNADNamespace      = "default"
 	testNADName           = "test-net"
 	testNetworkName       = testNADNamespace + "/" + testNADName
+	testCIDR              = "192.168.0.0/24"
+	testStartIP           = "192.168.0.100"
+	testEndIP             = "192.168.0.200"
+	testIPAddress1        = "192.168.0.111"
+	testIPAddress2        = "192.168.0.112"
+	testOutsideCIDRIP     = "192.168.1.111"
+	testOutsideRangeIP    = "192.168.0.50"
+	testMACAddress1       = "11:22:33:44:55:66"
+	testMACAddress2       = "22:33:44:55:66:77"
 )
 
 func newTestVirtualMachineNetworkConfigBuilder() *vmnetcfg.VmNetCfgBuilder {
@@ -134,6 +144,129 @@ func TestValidator_Create(t *testing.T) {
 				shouldErr: true,
 			},
 		},
+		{
+			name: "desired static ip inside pool is allowed",
+			given: input{
+				vmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig(testIPAddress1, testMACAddress1, testNetworkName).Build(),
+				ipPool: newTestIPPoolBuilder().
+					NetworkName(testNetworkName).
+					CIDR(testCIDR).
+					PoolRange(testStartIP, testEndIP).Build(),
+				nad: newTestNetworkAttachmentDefinitionBuilder().
+					Label(util.IPPoolNamespaceLabelKey, testIPPoolNamespace).
+					Label(util.IPPoolNameLabelKey, testIPPoolName).Build(),
+			},
+			expected: output{
+				shouldErr: false,
+			},
+		},
+		{
+			name: "desired static ip outside cidr is denied",
+			given: input{
+				vmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig(testOutsideCIDRIP, testMACAddress1, testNetworkName).Build(),
+				ipPool: newTestIPPoolBuilder().
+					NetworkName(testNetworkName).
+					CIDR(testCIDR).
+					PoolRange(testStartIP, testEndIP).Build(),
+				nad: newTestNetworkAttachmentDefinitionBuilder().
+					Label(util.IPPoolNamespaceLabelKey, testIPPoolNamespace).
+					Label(util.IPPoolNameLabelKey, testIPPoolName).Build(),
+			},
+			expected: output{
+				shouldErr: true,
+			},
+		},
+		{
+			name: "desired static ip outside pool range is denied",
+			given: input{
+				vmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig(testOutsideRangeIP, testMACAddress1, testNetworkName).Build(),
+				ipPool: newTestIPPoolBuilder().
+					NetworkName(testNetworkName).
+					CIDR(testCIDR).
+					PoolRange(testStartIP, testEndIP).Build(),
+				nad: newTestNetworkAttachmentDefinitionBuilder().
+					Label(util.IPPoolNamespaceLabelKey, testIPPoolNamespace).
+					Label(util.IPPoolNameLabelKey, testIPPoolName).Build(),
+			},
+			expected: output{
+				shouldErr: true,
+			},
+		},
+		{
+			name: "desired static ip marked excluded is denied",
+			given: input{
+				vmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig(testIPAddress1, testMACAddress1, testNetworkName).Build(),
+				ipPool: newTestIPPoolBuilder().
+					NetworkName(testNetworkName).
+					CIDR(testCIDR).
+					PoolRange(testStartIP, testEndIP).
+					Allocated(testIPAddress1, util.ExcludedMark).Build(),
+				nad: newTestNetworkAttachmentDefinitionBuilder().
+					Label(util.IPPoolNamespaceLabelKey, testIPPoolNamespace).
+					Label(util.IPPoolNameLabelKey, testIPPoolName).Build(),
+			},
+			expected: output{
+				shouldErr: true,
+			},
+		},
+		{
+			name: "desired static ip marked reserved is denied",
+			given: input{
+				vmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig(testIPAddress1, testMACAddress1, testNetworkName).Build(),
+				ipPool: newTestIPPoolBuilder().
+					NetworkName(testNetworkName).
+					CIDR(testCIDR).
+					PoolRange(testStartIP, testEndIP).
+					Allocated(testIPAddress1, util.ReservedMark).Build(),
+				nad: newTestNetworkAttachmentDefinitionBuilder().
+					Label(util.IPPoolNamespaceLabelKey, testIPPoolNamespace).
+					Label(util.IPPoolNameLabelKey, testIPPoolName).Build(),
+			},
+			expected: output{
+				shouldErr: true,
+			},
+		},
+		{
+			name: "desired static ip allocated to a different mac is denied",
+			given: input{
+				vmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig(testIPAddress1, testMACAddress1, testNetworkName).Build(),
+				ipPool: newTestIPPoolBuilder().
+					NetworkName(testNetworkName).
+					CIDR(testCIDR).
+					PoolRange(testStartIP, testEndIP).
+					Allocated(testIPAddress1, testMACAddress2).Build(),
+				nad: newTestNetworkAttachmentDefinitionBuilder().
+					Label(util.IPPoolNamespaceLabelKey, testIPPoolNamespace).
+					Label(util.IPPoolNameLabelKey, testIPPoolName).Build(),
+			},
+			expected: output{
+				shouldErr: true,
+			},
+		},
+		{
+			name: "duplicate desired static ip on same network is denied",
+			given: input{
+				vmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig(testIPAddress1, testMACAddress1, testNetworkName).
+					WithNetworkConfig(testIPAddress1, testMACAddress2, testNetworkName).Build(),
+				ipPool: newTestIPPoolBuilder().
+					NetworkName(testNetworkName).
+					CIDR(testCIDR).
+					PoolRange(testStartIP, testEndIP).Build(),
+				nad: newTestNetworkAttachmentDefinitionBuilder().
+					Label(util.IPPoolNamespaceLabelKey, testIPPoolNamespace).
+					Label(util.IPPoolNameLabelKey, testIPPoolName).Build(),
+			},
+			expected: output{
+				shouldErr: true,
+			},
+		},
 	}
 
 	nadGVR := schema.GroupVersionResource{
@@ -160,4 +293,155 @@ func TestValidator_Create(t *testing.T) {
 		err := validator.Create(&admission.Request{}, tc.given.vmNetCfg)
 		assert.Equal(t, tc.expected.shouldErr, err != nil, tc.name)
 	}
+}
+
+func TestValidator_Update(t *testing.T) {
+	type input struct {
+		oldVmNetCfg *networkv1.VirtualMachineNetworkConfig
+		vmNetCfg    *networkv1.VirtualMachineNetworkConfig
+		ipPool      *networkv1.IPPool
+		nad         *cniv1.NetworkAttachmentDefinition
+	}
+
+	testCases := []struct {
+		name     string
+		given    input
+		expected bool
+	}{
+		{
+			name: "desired static ip inside pool is allowed",
+			given: input{
+				oldVmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig("", testMACAddress1, testNetworkName).Build(),
+				vmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig(testIPAddress1, testMACAddress1, testNetworkName).Build(),
+				ipPool: newTestIPPoolBuilder().
+					NetworkName(testNetworkName).
+					CIDR(testCIDR).
+					PoolRange(testStartIP, testEndIP).Build(),
+				nad: newTestNetworkAttachmentDefinitionBuilder().
+					Label(util.IPPoolNamespaceLabelKey, testIPPoolNamespace).
+					Label(util.IPPoolNameLabelKey, testIPPoolName).Build(),
+			},
+			expected: false,
+		},
+		{
+			name: "desired static ip outside pool range is denied",
+			given: input{
+				oldVmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig("", testMACAddress1, testNetworkName).Build(),
+				vmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig(testOutsideRangeIP, testMACAddress1, testNetworkName).Build(),
+				ipPool: newTestIPPoolBuilder().
+					NetworkName(testNetworkName).
+					CIDR(testCIDR).
+					PoolRange(testStartIP, testEndIP).Build(),
+				nad: newTestNetworkAttachmentDefinitionBuilder().
+					Label(util.IPPoolNamespaceLabelKey, testIPPoolNamespace).
+					Label(util.IPPoolNameLabelKey, testIPPoolName).Build(),
+			},
+			expected: true,
+		},
+		{
+			name: "unchanged desired static ip does not require nad or ippool lookup",
+			given: input{
+				oldVmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig(testIPAddress1, testMACAddress1, testNetworkName).Build(),
+				vmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig(testIPAddress1, testMACAddress1, testNetworkName).Build(),
+			},
+			expected: false,
+		},
+		{
+			name: "removed network config does not require nad or ippool lookup",
+			given: input{
+				oldVmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig(testIPAddress1, testMACAddress1, testNetworkName).Build(),
+				vmNetCfg: newTestVirtualMachineNetworkConfigBuilder().Build(),
+			},
+			expected: false,
+		},
+		{
+			name: "removed desired static ip does not require nad or ippool lookup",
+			given: input{
+				oldVmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig(testIPAddress1, testMACAddress1, testNetworkName).Build(),
+				vmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig("", testMACAddress1, testNetworkName).Build(),
+			},
+			expected: false,
+		},
+		{
+			name: "changed desired static ip requires nad and ippool lookup",
+			given: input{
+				oldVmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig(testIPAddress1, testMACAddress1, testNetworkName).Build(),
+				vmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig(testIPAddress2, testMACAddress1, testNetworkName).Build(),
+			},
+			expected: true,
+		},
+		{
+			name: "new dynamic network config does not require nad or ippool lookup",
+			given: input{
+				oldVmNetCfg: newTestVirtualMachineNetworkConfigBuilder().Build(),
+				vmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig("", testMACAddress1, testNetworkName).Build(),
+			},
+			expected: false,
+		},
+		{
+			name: "changed desired static ip duplicated with unchanged config is denied",
+			given: input{
+				oldVmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig("", testMACAddress1, testNetworkName).
+					WithNetworkConfig(testIPAddress2, testMACAddress2, testNetworkName).Build(),
+				vmNetCfg: newTestVirtualMachineNetworkConfigBuilder().
+					WithNetworkConfig(testIPAddress2, testMACAddress1, testNetworkName).
+					WithNetworkConfig(testIPAddress2, testMACAddress2, testNetworkName).Build(),
+				ipPool: newTestIPPoolBuilder().
+					NetworkName(testNetworkName).
+					CIDR(testCIDR).
+					PoolRange(testStartIP, testEndIP).Build(),
+				nad: newTestNetworkAttachmentDefinitionBuilder().
+					Label(util.IPPoolNamespaceLabelKey, testIPPoolNamespace).
+					Label(util.IPPoolNameLabelKey, testIPPoolName).Build(),
+			},
+			expected: true,
+		},
+	}
+
+	nadGVR := schema.GroupVersionResource{
+		Group:    "k8s.cni.cncf.io",
+		Version:  "v1",
+		Resource: "network-attachment-definitions",
+	}
+
+	for _, tc := range testCases {
+		clientset := fake.NewSimpleClientset()
+		if tc.given.ipPool != nil {
+			err := clientset.Tracker().Add(tc.given.ipPool)
+			assert.NoError(t, err, "mock resource should add into fake controller tracker")
+		}
+		if tc.given.nad != nil {
+			err := clientset.Tracker().Create(nadGVR, tc.given.nad, tc.given.nad.Namespace)
+			assert.NoError(t, err, "mock resource should add into fake controller tracker")
+		}
+
+		ipPoolCache := fakeclient.IPPoolCache(clientset.NetworkV1alpha1().IPPools)
+		nadCache := fakeclient.NetworkAttachmentDefinitionCache(clientset.K8sCniCncfIoV1().NetworkAttachmentDefinitions)
+		validator := NewValidator(ipPoolCache, nadCache)
+
+		err := validator.Update(&admission.Request{}, tc.given.oldVmNetCfg, tc.given.vmNetCfg)
+		assert.Equal(t, tc.expected, err != nil, tc.name)
+	}
+}
+
+func TestValidator_Resource(t *testing.T) {
+	validator := NewValidator(nil, nil)
+
+	resource := validator.Resource()
+
+	assert.Contains(t, resource.OperationTypes, admissionregv1.Create)
+	assert.Contains(t, resource.OperationTypes, admissionregv1.Update)
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Harvester users need a way to request stable DHCP IP addresses for VM NICs through VM-level configuration. The vm-dhcp-controller already supports static lease behavior through `VirtualMachineNetworkConfig.spec.networkConfigs[].ipAddress`, but Harvester-created VMs did not have a controller path that populated this field from VM annotations.

Without this, users cannot reliably pin a desired IP per VM interface through the Harvester VM workflow, and changes to a desired IP for an existing MAC are not reconciled cleanly.

**Solution:**
Add support for `static-ip.harvesterhci.io/<nic-name>` annotations on `VirtualMachine` objects.

The VM controller now reads static IP annotations, matches them to VM interface names, validates basic IPv4 syntax, and writes the desired address into the generated `VirtualMachineNetworkConfig`.

The vmnetcfg controller now treats desired IP changes for an existing MAC as stale allocation state, so the old IP can be released and the new requested IP can be allocated during reconciliation.

The vmnetcfg webhook now validates requested static IPs on create and relevant updates. It rejects invalid requests such as non-IPv4 addresses, IPs outside the subnet or pool range, network or broadcast addresses, excluded/reserved IPs, duplicate desired IPs on the same network, and IPs already allocated to another MAC.

**Related Issue:**

harvester/harvester#5052

**Test plan:**

1. Prepare a Harvester cluster in v1.8.1
2. Install the vm-dhcp-controller add-on
3. Configure the vm-dhcp-controller add-on to use the custom-built images
4. Enable the vm-dhcp-controller add-on
5. Create a valid VM Network (NAD) and a proper IPPool resource
6. Create a VM with a static IP annotation
7. Check the VM has the desired static IP allocated and assigned
