### PR TITLE
chore: disable harvester update in v1.7 branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,12 @@
 {
   "extends": [
     "github>harvester/dependency-automation:renovate"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["github.com/harvester/harvester"],
+      "matchBaseBranches": ["v1.7"],
+      "allowedVersions": "~1.7.0"
+    }
   ]
 }


### PR DESCRIPTION
**Problem:**
- Disable https://github.com/harvester/vm-dhcp-controller/pull/170

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
- Update renovate config.
