### PR TITLE
chore(deps): bump go version to 1.26

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.25
+FROM registry.suse.com/bci/golang:1.26
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH=$DAPPER_HOST_ARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/vm-dhcp-controller
 
-go 1.25.2
+go 1.26.4
 
 replace (
 	github.com/google/gnostic-models => github.com/google/gnostic-models v0.6.9


### PR DESCRIPTION
For fixing #172. This is v1.7 specific.